### PR TITLE
Add snippets to create snippets

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -16,11 +16,15 @@ module.exports =
       @enableSnippetsInEditor(editorView) if editorView.attached
 
   loadAll: ->
+    @loadBundleSnippets => @loadUserSnippets => @loadPackageSnippets()
+
+  loadBundleSnippets: (callback) ->
+    bundledSnippetsPath = CSON.resolve(path.join(__dirname, 'snippets'))
+    @loadSnippetsFile(bundledSnippetsPath, callback)
+
+  loadUserSnippets: (callback) ->
     userSnippetsPath = CSON.resolve(path.join(atom.getConfigDirPath(), 'snippets'))
-    if userSnippetsPath
-      @loadSnippetsFile userSnippetsPath, => @loadPackageSnippets()
-    else
-      @loadPackageSnippets()
+    @loadSnippetsFile(userSnippetsPath, callback)
 
   loadPackageSnippets: ->
     packages = atom.packages.getLoadedPackages()

--- a/lib/snippets.cson
+++ b/lib/snippets.cson
@@ -1,0 +1,23 @@
+'.source.json':
+  'Atom Snippet':
+    prefix: 'snip'
+    body: """
+      {
+        "${1:.source.js}": {
+          "${2:Snippet Name}": {
+            "prefix": "${3:hello}",
+            "body": "${4:Hello World!}"
+          }
+        }
+      }
+    """
+
+'.source.coffee':
+  'Atom Snippet':
+    prefix: 'snip'
+    body: """
+      '${1:.source.js}':
+        '${2:Snippet Name}':
+          'prefix': '${3:hello}'
+          'body': '${4:Hello World!}'
+    """

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -291,6 +291,17 @@ describe "Snippets extension", ->
       runs ->
         expect(atom.syntax.getProperty(['.foo'], 'snippets.foo')?.constructor).toBe Snippet
 
+    it "loads the bundled snippet template snippets", ->
+      spyOn(console, 'warn')
+      snippets.loaded = false
+      snippets.loadAll()
+
+      waitsFor "all snippets to load", 30000, -> snippets.loaded
+
+      runs ->
+        expect(atom.syntax.getProperty(['.source.json'], 'snippets.snip')?.constructor).toBe Snippet
+        expect(atom.syntax.getProperty(['.source.coffee'], 'snippets.snip')?.constructor).toBe Snippet
+
   describe "snippet body parser", ->
     it "breaks a snippet body into lines, with each line containing tab stops at the appropriate position", ->
       bodyTree = snippets.getBodyParser().parse """


### PR DESCRIPTION
`snip<tab>` in cson/json files will now expand to a snippet template.

Fixes #7 
