### PR TITLE
Fix snippets with 10 or more indices

### DIFF
--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -4,13 +4,13 @@ bodyContentChar = !tabStop char:. { return char; }
 
 tabStop = simpleTabStop / tabStopWithoutPlaceholder / tabStopWithPlaceholder
 simpleTabStop = '$' index:[0-9]+ {
-  return { index: parseInt(index), content: [] };
+  return { index: parseInt(index.join("")), content: [] };
 }
 tabStopWithoutPlaceholder = '${' index:[0-9]+ '}' {
-  return { index: parseInt(index), content: [] };
+  return { index: parseInt(index.join("")), content: [] };
 }
 tabStopWithPlaceholder = '${' index:[0-9]+ ':' content:placeholderContent '}' {
-  return { index: parseInt(index), content: content };
+  return { index: parseInt(index.join("")), content: content };
 }
 placeholderContent = content:(tabStop / variable / placeholderContentText)* { return content; }
 placeholderContentText = text:placeholderContentChar+ { return text.join(''); }

--- a/lib/snippet.coffee
+++ b/lib/snippet.coffee
@@ -32,7 +32,7 @@ class Snippet
     extractTabStops(bodyTree)
     @lineCount = row + 1
     @tabStops = []
-    for index in _.keys(tabStopsByIndex).sort()
+    for index in _.keys(tabStopsByIndex).sort(((arg1, arg2) -> arg1-arg2))
       @tabStops.push tabStopsByIndex[index]
 
     bodyText.join('')


### PR DESCRIPTION
![bug](https://cloud.githubusercontent.com/assets/5219415/3098707/e7b4dd0c-e5ef-11e3-9882-daab3e44dcc3.gif)

Starting with index 10 it went really buggy (as you can see). The way it should look (and does now):

![coffeedocs](https://cloud.githubusercontent.com/assets/5219415/3098726/31008a56-e5f0-11e3-97e8-0c0a350aff70.gif)
