### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Select the _Atom > Open Your Snippets_ menu to add your own snippets.
 ## Snippet Format
 
 Snippets files are stored in a package's `snippets/` folder and also loaded
-from `~/.atom/snippet.cson`.
+from `~/.atom/snippets.cson`.
 
 Snippet files can be either `.json` or `.cson`.
 


### PR DESCRIPTION
I was wondering why snippets under `~/.atom/snippet.cson` weren't available. 

``` coffee
  getUserSnippetsPath: ->
    userSnippetsPath = CSON.resolve(path.join(atom.getConfigDirPath(), 'snippets'))
    userSnippetsPath ? path.join(atom.getConfigDirPath(), 'snippets.cson')
```
