### PR TITLE
Support for multiple cursors

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -106,14 +106,14 @@ module.exports =
     editor.snippetExpansions ?= []
 
     editorView.command 'snippets:expand', (event) =>
-      if @snippetsToExpandUnderCursor(editor)
+      if @snippetToExpandUnderCursor(editor)
         editor.snippetExpansions = []
-        @expandSnippetsUnderCursor(editor)
+        @expandSnippetsUnderCursors(editor)
       else
         event.abortKeyBinding()
 
     editorView.command 'snippets:next-tab-stop', (event) =>
-      if editor.snippetExpansions?.length > 0 and not @snippetsToExpandUnderCursor(editor)
+      if editor.snippetExpansions?.length > 0 and not @snippetToExpandUnderCursor(editor)
         expansion?.goToNextTabStop() for expansion in editor.snippetExpansions
       else
         event.abortKeyBinding()
@@ -162,7 +162,7 @@ module.exports =
         snippets[snippetPrefix] ?= snippet
     snippets
 
-  snippetsToExpandUnderCursor: (editor) ->
+  snippetToExpandUnderCursor: (editor) ->
     return false unless editor.getSelection().isEmpty()
     snippets = @getSnippets(editor)
     return false if _.isEmpty(snippets)
@@ -173,8 +173,8 @@ module.exports =
     prefix = prefix[0]
     @snippetForPrefix(snippets, prefix)
 
-  expandSnippetsUnderCursor: (editor) ->
-    return false unless snippet = @snippetsToExpandUnderCursor(editor)
+  expandSnippetsUnderCursors: (editor) ->
+    return false unless snippet = @snippetToExpandUnderCursor(editor)
 
     editor.transact =>
       cursors = editor.getCursors()


### PR DESCRIPTION
Closes #26

It expands for each cursor and enables us to edit them simultaneously:
![gifrecord_2014-06-21_170600](https://cloud.githubusercontent.com/assets/5219415/3349171/2ceeec5e-f956-11e3-894c-2f31381ac16c.gif)

It only expands if all cursors match the same snippet:
![gifrecord_2014-06-21_170741](https://cloud.githubusercontent.com/assets/5219415/3349174/3e4da53a-f956-11e3-9ba5-3a6bcceec96a.gif)

And it works from Snippets Available:
![gifrecord_2014-06-21_170822](https://cloud.githubusercontent.com/assets/5219415/3349177/4ae1715a-f956-11e3-8141-7f46b1bace84.gif)

Greets! 
