### PR TITLE
added special variables

### DIFF
--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -1,6 +1,7 @@
-bodyContent = content:(tabStop / bodyContentText)* { return content; }
+
+bodyContent = content:(tabStop / variable / bodyContentText)* { return content; }
 bodyContentText = text:bodyContentChar+ { return text.join(''); }
-bodyContentChar = !tabStop char:. { return char; }
+bodyContentChar = !tabStop !variable  char:. { return char; }
 
 tabStop = simpleTabStop / tabStopWithoutPlaceholder / tabStopWithPlaceholder
 simpleTabStop = '$' index:[0-9]+ {
@@ -16,9 +17,7 @@ placeholderContent = content:(tabStop / variable / placeholderContentText)* { re
 placeholderContentText = text:placeholderContentChar+ { return text.join(''); }
 placeholderContentChar = !tabStop !variable char:[^}] { return char; }
 
-variable = '${' variableContent '}' {
-  return ''; // we eat variables and do nothing with them for now
-}
-variableContent = content:(variable / variableContentText)* { return content; }
+variable = '${' variable:variableContentText '}' {return {variable:variable};}
+/*variableContent = content:(variable / variableContentText)* { return content; }*/
 variableContentText = text:variableContentChar+ { return text.join(''); }
-variableContentChar = !variable char:[^}] { return char; }
+variableContentChar = !tabStop !variable char:[^}] { return char; }

--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 {Subscriber} = require 'emissary'
+variable     = require './variable'
 
 module.exports =
 class SnippetExpansion
@@ -15,14 +16,15 @@ class SnippetExpansion
 
     @editor.transact =>
       newRange = @editor.transact =>
-        @cursor.selection.insertText(snippet.body, autoIndent: false)
+        body = variable.fixLineNum(snippet.body, startPosition)
+        @cursor.selection.insertText(body, autoIndent: false)
       if snippet.tabStops.length > 0
         @subscribe @cursor, 'moved', (event) => @cursorMoved(event)
         @placeTabStopMarkers(startPosition, snippet.tabStops)
         @snippets.addExpansion(@editor, this)
         @editor.normalizeTabsInBufferRange(newRange)
       @indentSubsequentLines(startPosition.row, snippet) if snippet.lineCount > 1
-
+    
   cursorMoved: ({oldBufferPosition, newBufferPosition, textChanged}) ->
     return if @settingTabStop or textChanged
     oldTabStops = @tabStopsForBufferPosition(oldBufferPosition)

--- a/lib/snippet.coffee
+++ b/lib/snippet.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 {Range} = require 'atom'
+varValue = require './variable'
 
 module.exports =
 class Snippet
@@ -21,6 +22,10 @@ class Snippet
           extractTabStops(content)
           tabStopsByIndex[index] ?= []
           tabStopsByIndex[index].push new Range(start, [row, column])
+        else if (variable = segment.variable)
+          value = varValue(variable)
+          bodyText.push(value)
+          column += value.length
         else if _.isString(segment)
           bodyText.push(segment)
           segmentLines = segment.split('\n')

--- a/lib/snippet.coffee
+++ b/lib/snippet.coffee
@@ -1,6 +1,6 @@
 _ = require 'underscore-plus'
-{Range} = require 'atom'
-varValue = require './variable'
+{Range}  = require 'atom'
+variable = require './variable'
 
 module.exports =
 class Snippet
@@ -22,8 +22,8 @@ class Snippet
           extractTabStops(content)
           tabStopsByIndex[index] ?= []
           tabStopsByIndex[index].push new Range(start, [row, column])
-        else if (variable = segment.variable)
-          value = varValue(variable)
+        else if (varName = segment.variable)
+          value = variable.getValue(varName)
           bodyText.push(value)
           column += value.length
         else if _.isString(segment)

--- a/lib/variable.coffee
+++ b/lib/variable.coffee
@@ -1,8 +1,4 @@
 
-###
-
-###
-
 fs     = require 'fs'
 path   = require 'path'
 moment = require 'moment'
@@ -10,10 +6,11 @@ moment = require 'moment'
 lineNumMagicStr = '~l#N~'
 
 exports.getValue = (varName) ->
-  if not varName then return ''
-  
   unixify  = (path) -> path.replace(/\\/g, '/')
+  
   editor   = atom.workspace.getActiveTextEditor()
+  if not varName or not editor then return ''
+  
   filePath = unixify(editor.getPath())
   project  = atom.project
   for projectPath in project.getPaths() 

--- a/lib/variable.coffee
+++ b/lib/variable.coffee
@@ -6,10 +6,12 @@ moment = require 'moment'
 module.exports = (varName) ->
   if not varName then return ''
   
+  unixify  = (path) -> path.replace(/\\/g, '/')
   editor   = atom.workspace.getActiveTextEditor()
-  filePath = editor.getPath()
+  filePath = unixify(editor.getPath())
   project  = atom.project
   for projectPath in project.getPaths() 
+    projectPath = unixify(projectPath)
     if filePath[0...projectPath.length] is projectPath then break
   
   varNameBody = varName[1...]
@@ -38,7 +40,8 @@ module.exports = (varName) ->
         when 'extname'     then path.extname  filePath
         when 'sep'         then path.sep
         when 'delimiter'   then path.delimiter
-        when 'project'     then projectPath
+        when 'projectpath' then projectPath
+        when 'project'     then projectPath.split('/')[-1..-1][0]
         when 'filenamerel' then projectRel
         when 'dirnamerel'  then path.dirname projectRel
         when 'line'        then editor.getCursorBufferPosition().row + 1

--- a/lib/variable.coffee
+++ b/lib/variable.coffee
@@ -1,0 +1,47 @@
+
+fs     = require 'fs'
+path   = require 'path'
+moment = require 'moment'
+
+module.exports = (varName) ->
+  if not varName then return ''
+  
+  editor   = atom.workspace.getActiveTextEditor()
+  filePath = editor.getPath()
+  project  = atom.project
+  for projectPath in project.getPaths() 
+    if filePath[0...projectPath.length] is projectPath then break
+  
+  varNameBody = varName[1...]
+  switch varName[0]
+    when '-'
+      moment().format(varNameBody)
+    
+    when ':'
+      try
+        value = JSON.parse fs.readFileSync path.join(projectPath, 'package.json')
+      catch e
+        return ' <unable to load package.json for variable: "' + varName + '"> '
+      for propName in varNameBody.split ':'
+        if not (value = value[propName])
+          return ' <package.json does not have property "' + varNameBody + '"> '
+      if typeof value isnt 'string'
+        return ' <expected string for package.json property "' + varNameBody + '"> '
+      value
+    
+    when '/'
+      projectRel = filePath[projectPath.length+1...]
+      switch varNameBody
+        when 'filename'    then               filePath
+        when 'dirname'     then path.dirname  filePath
+        when 'basename'    then path.basename filePath
+        when 'extname'     then path.extname  filePath
+        when 'sep'         then path.sep
+        when 'delimiter'   then path.delimiter
+        when 'project'     then projectPath
+        when 'filenamerel' then projectRel
+        when 'dirnamerel'  then path.dirname projectRel
+        when 'line'        then editor.getCursorBufferPosition().row + 1
+        else ' <unknown / variable: "' + varName + '"> '
+
+    else ' <prefix not one of "-:/" in variable "' + varName + '"> '

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "emissary": "1.x",
     "fs-plus": "2.x",
     "loophole": "^0.1.0",
+    "moment": "2.x",
     "pathwatcher": "^2.0",
     "pegjs": "~0.8.0",
     "season": "1.x",

--- a/spec/fixtures/package.json
+++ b/spec/fixtures/package.json
@@ -1,0 +1,1 @@
+{ "variable-prop1": {"variable-prop2": "variable-value"} }

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -116,6 +116,34 @@ describe "Snippets extension", ->
               $0one${1} ${2:two} three${3}
             """
 
+          "variables":
+            prefix: "var1"
+            body: """
+              xxx${/basename} yyy ${/extname}zzz ${/line} ${/dirnamerel}${:variable-prop1:variable-prop2}
+            """
+          "invalid variables":
+            prefix: "var2"
+            body: """
+              ${abc}${:variable-prop1}${:X:variable-prop2}
+            """
+
+    describe "when the snippet contains variables", ->
+      it "evaluates the variables", ->
+        editor.setText('')
+        editor.insertText('var1')
+        editorView.trigger 'snippets:expand'
+        expect(buffer.getText()).toBe 'xxxsample.js yyy .jszzz 1 .variable-value'
+
+    describe "when the snippet contains invalid variables", ->
+      it "inserts error messages", ->
+        editor.setText('')
+        editor.insertText('var2')
+        editorView.trigger 'snippets:expand'
+        expect(buffer.getText()).toBe \
+          ' <prefix not one of "-:/" in variable "abc"> ' +
+          ' <expected string for package.json property "variable-prop1"> ' +
+          ' <package.json does not have property "X:variable-prop2"> '
+                                      
     describe "when the snippet body is invalid or missing", ->
       it "does not register the snippet", ->
         editor.setText('')
@@ -616,19 +644,6 @@ describe "Snippets extension", ->
         "the "
         { index: 4, content: ["lazy"] },
         " dog"
-      ]
-
-    it "removes interpolated variables in placeholder text (we don't currently support it)", ->
-      bodyTree = snippets.getBodyParser().parse """
-        module ${1:ActiveRecord::${TM_FILENAME/(?:\\A|_)([A-Za-z0-9]+)(?:\\.rb)?/(?2::\\u$1)/g}}
-      """
-
-      expect(bodyTree).toEqual [
-        "module ",
-        {
-          "index": 1,
-          "content": ["ActiveRecord::", ""]
-        }
       ]
 
   describe "when atom://.atom/snippets is opened", ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -133,7 +133,8 @@ describe "Snippets extension", ->
         editor.setText('')
         editor.insertText('var1')
         editorView.trigger 'snippets:expand'
-        expect(buffer.getText()).toBe 'xxxsample.js yyy .jszzz 1fixtures . variable-value'
+        expect(buffer.getText()).toBe 'xxxsample.js yyy .jszzz     1fixtures . variable-value'
+        
     describe "when the snippet contains invalid variables", ->
       it "inserts error messages", ->
         editor.setText('')

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -115,12 +115,13 @@ describe "Snippets extension", ->
             body: """
               $0one${1} ${2:two} three${3}
             """
-
+            
           "variables":
             prefix: "var1"
             body: """
-              xxx${/basename} yyy ${/extname}zzz ${/line} ${/dirnamerel}${:variable-prop1:variable-prop2}
+              xxx${/basename} yyy ${/extname}zzz ${/line}${/project} ${/dirnamerel} ${:variable-prop1:variable-prop2}
             """
+            
           "invalid variables":
             prefix: "var2"
             body: """
@@ -132,8 +133,7 @@ describe "Snippets extension", ->
         editor.setText('')
         editor.insertText('var1')
         editorView.trigger 'snippets:expand'
-        expect(buffer.getText()).toBe 'xxxsample.js yyy .jszzz 1 .variable-value'
-
+        expect(buffer.getText()).toBe 'xxxsample.js yyy .jszzz 1fixtures . variable-value'
     describe "when the snippet contains invalid variables", ->
       it "inserts error messages", ->
         editor.setText('')


### PR DESCRIPTION
Adds variables like `${/filename}` that expand into special values, much like `__filename` in node.  The prefix character is designed to not conflict with normal variable names if/when they are supported.  I don't know where docs are supposed to go so here they are ...

### Special variables in snippets package

Add variables of the form `${Xname}` where the first character `X` is one of `/`, `:`, or `-`.  The suffix `name` must follow specific values or syntax.  Examples ...

### files and paths
   - **${/filename}**   =>  /root/proj/lib/main.coffee
   - **${/dirname}**   =>  /root/proj/lib   
   - **${/basename}**   =>  main.coffee
   - **${/extname}**   =>  .coffee
   - **${/sep}**   =>  /
   - **${/delimiter}**   =>  :
   - **${/projectpath}**   => /root/proj
   - **${/project}**   => proj
   - **${/filenamerel}**   => lib/main.coffee
   - **${/dirnamerel}**   => lib
   - **${/line}**   => 27  (line number of cursor position)

### date & times
   - **${-any-moment-format}**  current time in any format provided by the [moment](http://momentjs.com/docs/#/displaying/) npm package
      - ${-MMMM Do YYYY, h:mm:ss a} =>   November 22nd 2014, 2:24:26 am
      - ${-dddd}                    =>   Saturday
      - ${-MMM Do YY}               =>   Nov 22nd 14

### package.json
   - **${:path:in:project:json}**  Shows value from project.json file
      - ${:name}   =>  moment
      - ${:version} => 2.8.4
      - ${:repository:url}   =>  https://github.com/moment/moment.git
