### PR TITLE
Store snippets as plain objects in config

### DIFF
--- a/lib/snippet.coffee
+++ b/lib/snippet.coffee
@@ -2,37 +2,48 @@ _ = require 'underscore-plus'
 {Range} = require 'atom'
 
 module.exports =
-class Snippet
-  constructor: ({@name, @prefix, @bodyText, bodyTree}) ->
-    @body = @extractTabStops(bodyTree)
+  create: ({name, prefix, bodyText, bodyTree}) ->
+    {body, tabStops, lineCount} = extractTabStops(bodyTree)
+    {
+      name,
+      prefix,
+      bodyText,
+      body,
+      tabStops, lineCount
+    }
 
-  extractTabStops: (bodyTree) ->
-    tabStopsByIndex = {}
-    bodyText = []
-    [row, column] = [0, 0]
+extractTabStops = (bodyTree) ->
+  tabStopsByIndex = {}
+  tabStops = []
+  bodyText = []
+  lineCount = 0
+  [row, column] = [0, 0]
 
-    # recursive helper function; mutates vars above
-    extractTabStops = (bodyTree) ->
-      for segment in bodyTree
-        if segment.index?
-          { index, content } = segment
-          index = Infinity if index == 0
-          start = [row, column]
-          extractTabStops(content)
-          tabStopsByIndex[index] ?= []
-          tabStopsByIndex[index].push new Range(start, [row, column])
-        else if _.isString(segment)
-          bodyText.push(segment)
-          segmentLines = segment.split('\n')
-          column += segmentLines.shift().length
-          while (nextLine = segmentLines.shift())?
-            row += 1
-            column = nextLine.length
+  extract = (bodyTree) ->
+    for segment in bodyTree
+      if segment.index?
+        { index, content } = segment
+        index = Infinity if index == 0
+        start = [row, column]
+        extract(content)
+        tabStopsByIndex[index] ?= []
+        tabStopsByIndex[index].push new Range(start, [row, column])
+      else if _.isString(segment)
+        bodyText.push(segment)
+        segmentLines = segment.split('\n')
+        column += segmentLines.shift().length
+        while (nextLine = segmentLines.shift())?
+          row += 1
+          column = nextLine.length
 
-    extractTabStops(bodyTree)
-    @lineCount = row + 1
-    @tabStops = []
-    for index in _.keys(tabStopsByIndex).sort(((arg1, arg2) -> arg1-arg2))
-      @tabStops.push tabStopsByIndex[index]
+  extract(bodyTree)
 
-    bodyText.join('')
+  tabStops = []
+  for index in _.keys(tabStopsByIndex).sort((a, b) -> a - b)
+    tabStops.push tabStopsByIndex[index]
+
+  {
+    tabStops,
+    lineCount: row + 1,
+    body: bodyText.join('')
+  }

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -120,7 +120,8 @@ module.exports =
 
         # if `add` isn't called by the loader task (in specs for example), we need to parse the body
         bodyTree ?= @getBodyParser().parse(body)
-        snippet = new Snippet({name, prefix, bodyTree, bodyText: body})
+        snippet = Snippet.create({name, prefix, bodyTree, bodyText: body})
+
         snippetsByPrefix[snippet.prefix] = snippet
       disposable.add atom.config.addScopedSettings(filePath, selector, snippets: snippetsByPrefix)
     disposable
@@ -218,6 +219,6 @@ module.exports =
   insert: (snippet, editor=atom.workspace.getActiveTextEditor(), cursor=editor.getLastCursor()) ->
     if typeof snippet is 'string'
       bodyTree = @getBodyParser().parse(snippet)
-      snippet = new Snippet({name: '__anonymous', prefix: '', bodyTree, bodyText: snippet})
+      snippet = Snippet.create({name: '__anonymous', prefix: '', bodyTree, bodyText: snippet})
 
     new SnippetExpansion(snippet, editor, cursor, this)

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -3,7 +3,6 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require('temp').track()
 
-Snippet = require '../lib/snippet'
 Snippets = require '../lib/snippets'
 SnippetsAvailable = require '../lib/snippets-available'
 
@@ -541,7 +540,9 @@ describe "Snippets extension", ->
       waitsFor "all snippets to load", 30000, -> snippets.loaded
 
       runs ->
-        expect(atom.config.get(['.test'], 'snippets.test')?.constructor).toBe Snippet
+        snippet = atom.config.get(['.test'], 'snippets.test')
+        expect(snippet.prefix).toBe("test")
+        expect(snippet.body).toBe("testing 123")
 
         # warn about junk-file, but don't even try to parse a hidden file
         expect(console.warn).toHaveBeenCalled()
@@ -565,7 +566,9 @@ describe "Snippets extension", ->
       waitsFor "all snippets to load", 30000, -> snippets.loaded
 
       runs ->
-        expect(atom.config.get(['.foo'], 'snippets.foo')?.constructor).toBe Snippet
+        snippet = atom.config.get(['.foo'], 'snippets.foo')
+        expect(snippet.prefix).toBe("foo")
+        expect(snippet.body).toBe("bar")
 
     it "loads ~/.atom/snippets.cson when it exists", ->
       fs.writeFileSync path.join(configDirPath, 'snippets.cson'), """
@@ -581,7 +584,9 @@ describe "Snippets extension", ->
       waitsFor "all snippets to load", 30000, -> snippets.loaded
 
       runs ->
-        expect(atom.config.get(['.foo'], 'snippets.foo')?.constructor).toBe Snippet
+        snippet = atom.config.get(['.foo'], 'snippets.foo')
+        expect(snippet.prefix).toBe("foo")
+        expect(snippet.body).toBe("bar")
 
     it "notifies the user when the file cannot be loaded", ->
       spyOn(atom.notifications, 'addError') if atom.notifications?
@@ -608,8 +613,8 @@ describe "Snippets extension", ->
       waitsFor "all snippets to load", 30000, -> snippets.loaded
 
       runs ->
-        expect(atom.config.get(['.source.json'], 'snippets.snip')?.constructor).toBe Snippet
-        expect(atom.config.get(['.source.coffee'], 'snippets.snip')?.constructor).toBe Snippet
+        expect(atom.config.get(['.source.json'], 'snippets.snip').prefix).toBe("snip")
+        expect(atom.config.get(['.source.coffee'], 'snippets.snip').prefix).toBe("snip")
 
   describe "snippet body parser", ->
     it "breaks a snippet body into lines, with each line containing tab stops at the appropriate position", ->
@@ -690,7 +695,9 @@ describe "Snippets extension", ->
         atom.config.get(['.test'], 'snippets.test')?
 
       runs ->
-        expect(atom.config.get(['.test'], 'snippets.test')?.constructor).toBe Snippet
+        snippet = atom.config.get(['.test'], 'snippets.test')
+        expect(snippet.prefix).toBe "test"
+        expect(snippet.body).toBe "testing 123"
         fs.removeSync(snippetsPath)
 
       waitsFor "snippets to be removed", ->


### PR DESCRIPTION
The config merges objects, so objects with custom
classes get turned into plain objects.
