### PR TITLE
Use new signature for atom.config.get

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -191,7 +191,7 @@ module.exports =
     longestPrefixMatch
 
   getSnippets: (editor) ->
-    atom.config.get(editor.getLastCursor().getScopeDescriptor(), 'snippets')
+    atom.config.get('snippets', scope: editor.getLastCursor().getScopeDescriptor())
 
   snippetToExpandUnderCursor: (editor) ->
     return false unless editor.getLastSelection().isEmpty()

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -94,7 +94,7 @@ module.exports =
         userSnippetsFile = new File(userSnippetsPath)
         userSnippetsFile.on 'moved removed contents-changed', =>
           atom.config.transact =>
-            atom.config.scopedSettingsStore.removePropertiesForSource(userSnippetsPath)
+            atom.config.unset(null, source: userSnippetsPath)
             @loadSnippetsFile userSnippetsPath, (result) =>
               @add(userSnippetsPath, result)
         callback(new Disposable -> userSnippetsFile.off())
@@ -142,7 +142,6 @@ module.exports =
       callback(object)
 
   add: (filePath, snippetsBySelector) ->
-    disposable = new CompositeDisposable
     for selector, snippetsByName of snippetsBySelector
       snippetsByPrefix = {}
       for name, attributes of snippetsByName
@@ -153,8 +152,7 @@ module.exports =
         bodyTree ?= @getBodyParser().parse(body)
         snippet = new Snippet({name, prefix, bodyTree, bodyText: body})
         snippetsByPrefix[snippet.prefix] = snippet
-      disposable.add atom.config.addScopedSettings(filePath, selector, snippets: snippetsByPrefix)
-    disposable
+      atom.config.set('snippets', snippetsByPrefix, source: filePath, scopeSelector: selector)
 
   getBodyParser: ->
     @bodyParser ?= require './snippet-body-parser'
@@ -169,6 +167,7 @@ module.exports =
   # Get a RegExp of all the characters used in the snippet prefixes
   wordRegexForSnippets: (snippets) ->
     prefixes = {}
+
     for prefix of snippets
       prefixes[character] = true for character in prefix
     prefixCharacters = Object.keys(prefixes).join('')

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -35,25 +35,25 @@ describe "Snippet Loading", ->
     activateSnippetsPackage()
 
     runs ->
-      jsonSnippet = atom.config.get(['.source.json'], 'snippets.snip')
+      jsonSnippet = atom.config.get('snippets.snip', scope: ['.source.json'])
       expect(jsonSnippet.name).toBe 'Atom Snippet'
       expect(jsonSnippet.prefix).toBe 'snip'
-      expect(jsonSnippet.body).toContain('"prefix":')
-      expect(jsonSnippet.body).toContain('"body":')
+      expect(jsonSnippet.body).toContain '"prefix":'
+      expect(jsonSnippet.body).toContain '"body":'
       expect(jsonSnippet.tabStops.length).toBeGreaterThan(0)
 
-      csonSnippet = atom.config.get(['.source.coffee'], 'snippets.snip')
+      csonSnippet = atom.config.get('snippets.snip', scope: ['.source.coffee'])
       expect(csonSnippet.name).toBe 'Atom Snippet'
       expect(csonSnippet.prefix).toBe 'snip'
-      expect(csonSnippet.body).toContain ("'prefix':")
-      expect(csonSnippet.body).toContain ("'body':")
+      expect(csonSnippet.body).toContain "'prefix':"
+      expect(csonSnippet.body).toContain "'body':"
       expect(csonSnippet.tabStops.length).toBeGreaterThan(0)
 
   it "loads non-hidden snippet files from atom packages with snippets directories", ->
     activateSnippetsPackage()
 
     runs ->
-      snippet = atom.config.get(['.test'], 'snippets.test')
+      snippet = atom.config.get('snippets.test', scope: ['.test'])
       expect(snippet.prefix).toBe 'test'
       expect(snippet.body).toBe 'testing 123'
 
@@ -80,7 +80,7 @@ describe "Snippet Loading", ->
       activateSnippetsPackage()
 
     it "loads the snippets from that file", ->
-      snippet = atom.config.get(['.foo'], 'snippets.foo')
+      snippet = atom.config.get('snippets.foo', scope: ['.foo'])
       expect(snippet.name).toBe 'foo snippet'
       expect(snippet.prefix).toBe "foo"
       expect(snippet.body).toBe "bar1"
@@ -99,13 +99,13 @@ describe "Snippet Loading", ->
         """
 
         waitsFor "snippets to be changed", ->
-          atom.config.get(['.foo'], 'snippets.foo').body is 'bar2'
+          atom.config.get('snippets.foo', scope: ['.foo'])?.body is 'bar2'
 
         runs ->
           fs.writeFileSync path.join(configDirPath, 'snippets.json'), ""
 
         waitsFor "snippets to be removed", ->
-          not atom.config.get(['.foo'], 'snippets.foo')?
+          not atom.config.get('snippets.foo', scope: ['.foo'])?
 
   describe "when ~/.atom/snippets.cson exists", ->
     beforeEach ->
@@ -118,7 +118,7 @@ describe "Snippet Loading", ->
       activateSnippetsPackage()
 
     it "loads the snippets from that file", ->
-      snippet = atom.config.get(['.foo'], 'snippets.foo')
+      snippet = atom.config.get('snippets.foo', scope: ['.foo'])
       expect(snippet.name).toBe 'foo snippet'
       expect(snippet.prefix).toBe "foo"
       expect(snippet.body).toBe "bar1"
@@ -133,13 +133,13 @@ describe "Snippet Loading", ->
         """
 
         waitsFor "snippets to be changed", ->
-          atom.config.get(['.foo'], 'snippets.foo').body is 'bar2'
+          atom.config.get('snippets.foo', scope: ['.foo']).body is 'bar2'
 
         runs ->
           fs.writeFileSync path.join(configDirPath, 'snippets.cson'), ""
 
         waitsFor "snippets to be removed", ->
-          not atom.config.get(['.foo'], 'snippets.foo')?
+          not atom.config.get('snippets.foo', scope: ['.foo'])?
 
   it "notifies the user when the user snippets file cannot be loaded", ->
     fs.writeFileSync path.join(configDirPath, 'snippets.cson'), """


### PR DESCRIPTION
:warning: Depends on atom/atom@a1b4820c044073d2e46d0e2505ae7a1ee7e89272 and atom/atom#4773 being released in v0.166 :warning: