### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-Select the _Atom > Open Your Snippets_ menu to add your own snippets.
+Select the _Edit tab > Open Your Snippets_ menu option to add your own snippets.
 
 ## Snippet Format
 


### PR DESCRIPTION
In recent Atom builds, the Open your Snippets menu is in the Edit tab. This PR should correct this.