### PR TITLE
Don't trigger expansion when prefix is part of a larger word

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -186,7 +186,9 @@ module.exports =
     cursors = editor.getCursors()
     for cursor in cursors
       prefixStart = cursor.getBeginningOfCurrentWordBufferPosition({wordRegex})
-      editor.getTextInRange([prefixStart, cursor.getBufferPosition()])
+      wordStart = cursor.getBeginningOfCurrentWordBufferPosition()
+      if prefixStart.isLessThanOrEqual(wordStart)
+        editor.getTextInRange([prefixStart, cursor.getBufferPosition()])
 
   # Get a RegExp of all the characters used in the snippet prefixes
   wordRegexForSnippets: (snippets) ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -320,6 +320,12 @@ describe "Snippets extension", ->
           expect(editor.lineTextForBufferRow(0)).toBe "@this is a testvar quicksort = function () {"
           expect(editor.getCursorScreenPosition()).toEqual [0, 15]
 
+    describe "when the word preceding the cursor ends with a snippet prefix", ->
+      it "inserts a tab as normal", ->
+        editor.insertText("dat1")
+        simulateTabKeyEvent()
+        expect(editor.lineTextForBufferRow(0)).toBe "dat1  var quicksort = function () {"
+
     describe "when the letters preceding the cursor don't match a snippet", ->
       it "inserts a tab as normal", ->
         editor.insertText("xxte")


### PR DESCRIPTION
Currently, if a snippet prefix precedes the cursor, snippet expansion is triggered by the `tab` key. This PR *prevents* triggering snippet expansion if the snippet prefix preceding the cursor is part of a larger word, as defined by the `editor.nonWordCharacters` config setting. 

I'm not sure if this is the right thing to do, but I think it addresses issues raised by @dsandstrom in #59.

