### PR TITLE
Support escaped $ symbol in snippet body

### DIFF
--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -1,7 +1,8 @@
 bodyContent = content:(tabStop / bodyContentText)* { return content; }
 bodyContentText = text:bodyContentChar+ { return text.join(''); }
-bodyContentChar = !tabStop char:. { return char; }
+bodyContentChar = escaped / !tabStop char:. { return char; }
 
+escaped = '\\' char:[$\\] { return char; }
 tabStop = simpleTabStop / tabStopWithoutPlaceholder / tabStopWithPlaceholder
 simpleTabStop = '$' index:[0-9]+ {
   return { index: parseInt(index.join("")), content: [] };

--- a/spec/body-parser-spec.coffee
+++ b/spec/body-parser-spec.coffee
@@ -36,3 +36,21 @@ describe "Snippet Body Parser", ->
         "content": ["ActiveRecord::", ""]
       }
     ]
+
+  it "skips escaped tabstops", ->
+    bodyTree = BodyParser.parse """
+      snippet $1 escaped \\$2 \\\\$3
+    """
+
+    expect(bodyTree).toEqual [
+      "snippet ",
+      {
+        "index": 1,
+        "content": []
+      },
+      "escaped $2 \\",
+      {
+        "index": 3,
+        "content": []
+      }
+    ]

--- a/spec/body-parser-spec.coffee
+++ b/spec/body-parser-spec.coffee
@@ -48,7 +48,7 @@ describe "Snippet Body Parser", ->
         "index": 1,
         "content": []
       },
-      "escaped $2 \\",
+      " escaped $2 \\",
       {
         "index": 3,
         "content": []


### PR DESCRIPTION
Allow escaped `$` in snippet body to allow strings that look like a tabstop.
E.g. output `\$1` as `$1`, not as `\` + tabstop

PS: I was unable to run Jasmine specs because of `Module did not self-register` error, but I tested it with online PEG playground