### PR TITLE
Terminate snippets when cursor gets destroyed

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -17,6 +17,7 @@ class SnippetExpansion
         @cursor.selection.insertText(snippet.body, autoIndent: false)
       if snippet.tabStops.length > 0
         @subscriptions.add @cursor.onDidChangePosition (event) => @cursorMoved(event)
+        @subscriptions.add @cursor.onDidDestroy => @destroy()
         @placeTabStopMarkers(startPosition, snippet.tabStops)
         @snippets.addExpansion(@editor, this)
         @editor.normalizeTabsInBufferRange(newRange)
@@ -70,6 +71,7 @@ class SnippetExpansion
         else
           newSelection = @editor.addSelectionForBufferRange(range)
           @subscriptions.add newSelection.cursor.onDidChangePosition (event) => @cursorMoved(event)
+          @subscriptions.add newSelection.cursor.onDidDestroy => @destroy()
           @selections.push newSelection
       markerSelected = true
 

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -431,6 +431,15 @@ describe "Snippets extension", ->
         expect(editor.lineTextForBufferRow(0)).toBe "with placeholder hello"
         expect(editor.lineTextForBufferRow(1)).toBe "without placeholder hellovar quicksort = function () {"
 
+      it "terminates the snippet when cursors are destroyed", ->
+        editor.setCursorScreenPosition([0, 0])
+        editor.insertText('t9b')
+        simulateTabKeyEvent()
+        editor.consolidateSelections()
+        simulateTabKeyEvent()
+
+        expect(editor.lineTextForBufferRow(1)).toEqual("without placeholder   ")
+
       it "terminates the snippet expansion if a new cursor moves outside the bounds of the tab stops", ->
         editor.setCursorScreenPosition([0, 0])
         editor.insertText('t9b')


### PR DESCRIPTION
Cursors were being already tracked, but only when moving them. When `Esc` gets pressed, cursors are not moved: editor, in facts, consolidates selections, thus destroying some of the cursors. This solves https://github.com/atom/atom/issues/4821

/cc: @izuzak @nathansobo 
