### PR TITLE
Fix same index tab stops exiting prematurely

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -17,7 +17,7 @@ class SnippetExpansion
         @cursor.selection.insertText(snippet.body, autoIndent: false)
       if snippet.tabStops.length > 0
         @subscriptions.add @cursor.onDidChangePosition (event) => @cursorMoved(event)
-        @subscriptions.add @cursor.onDidDestroy => @destroy()
+        @subscriptions.add @cursor.onDidDestroy => @cursorDestroyed()
         @placeTabStopMarkers(startPosition, snippet.tabStops)
         @snippets.addExpansion(@editor, this)
         @editor.normalizeTabsInBufferRange(newRange)
@@ -28,6 +28,8 @@ class SnippetExpansion
     oldTabStops = @tabStopsForBufferPosition(oldBufferPosition)
     newTabStops = @tabStopsForBufferPosition(newBufferPosition)
     @destroy() unless _.intersection(oldTabStops, newTabStops).length
+
+  cursorDestroyed: -> @destroy() unless @settingTabStop
 
   placeTabStopMarkers: (startPosition, tabStopRanges) ->
     for ranges in tabStopRanges
@@ -71,7 +73,7 @@ class SnippetExpansion
         else
           newSelection = @editor.addSelectionForBufferRange(range)
           @subscriptions.add newSelection.cursor.onDidChangePosition (event) => @cursorMoved(event)
-          @subscriptions.add newSelection.cursor.onDidDestroy => @destroy()
+          @subscriptions.add newSelection.cursor.onDidDestroy => @cursorDestroyed()
           @selections.push newSelection
       markerSelected = true
 

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -114,6 +114,7 @@ describe "Snippets extension", ->
               with placeholder ${1:test}
               without placeholder $1
               second tabstop $2
+              third tabstop $3
             """
 
           "large indices":
@@ -453,6 +454,20 @@ describe "Snippets extension", ->
         # this should insert whitespace instead of going through tabstops of the previous destroyed snippet
         simulateTabKeyEvent()
         expect(editor.lineTextForBufferRow(2).indexOf("  second")).toBe 0
+
+      it "moves to the second tabstop after a multi-caret tabstop", ->
+        editor.setCursorScreenPosition([0, 0])
+        editor.insertText('t9b')
+        simulateTabKeyEvent()
+        editor.insertText('line 1')
+
+        simulateTabKeyEvent()
+        editor.insertText('line 2')
+
+        simulateTabKeyEvent()
+        editor.insertText('line 3')
+
+        expect(editor.lineTextForBufferRow(2).indexOf("line 2 ")).toBe -1
 
     describe "when the snippet contains tab stops with an index >= 10", ->
       it "parses and orders the indices correctly", ->


### PR DESCRIPTION
After testing, I'm convinced that destruction of `newSelection` does not need to be handled. Handling cursor change should be enough, and it doesn't have the side effect of breaking the tab stops.

Fixes #118