### PR TITLE
Add snippet to create snippets under a source definition

### DIFF
--- a/lib/snippets.cson
+++ b/lib/snippets.cson
@@ -5,11 +5,20 @@
       {
         "${1:.source.js}": {
           "${2:Snippet Name}": {
-            "prefix": "${3:hello}",
+            "prefix": "${3:Snippet Trigger}",
             "body": "${4:Hello World!}"
           }
         }
       }$5
+    """
+
+  'Atom Snippet Keys':
+    prefix: 'snipk'
+    body: """
+      "${1:Snippet Name}": {
+        "prefix": "${2:Snippet Trigger}",
+        "body": "${3:Hello World!}"
+      }$4
     """
 
   'Atom Keymap':
@@ -28,8 +37,16 @@
     body: """
       '${1:.source.js}':
         '${2:Snippet Name}':
-          'prefix': '${3:hello}'
+          'prefix': '${3:Snippet Trigger}'
           'body': '${4:Hello World!}'$5
+    """
+
+  'Atom Snippet Keys':
+    prefix: 'snipk'
+    body: """
+      '${1:Snippet Name}':
+        'prefix': '${2:Snippet Trigger}'
+        'body': '${3:Hello World!}'$5
     """
 
   'Atom Keymap':


### PR DESCRIPTION
Hi,

When I'm writing snippets it's really common to create many snippets under one source definition, so I added a snippet for that.

Not sure if snipk/"Atom Snippet Keys" is the best naming for that but it fits.

I also changed the placeholder for prefix because I think it would be easier to understand. Actually there is any reason why the key is not called "trigger" instead of "prefix"? I think it would be much easier to understand, if you guys think it is a good idea I can try to implement it maintaining compatibility, although I think that changing it at this point will probably cause more confusion than benefits.