### PR TITLE
Handle escaped characters in tab-stop placeholder content

### DIFF
--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -2,7 +2,7 @@ bodyContent = content:(tabStop / bodyContentText)* { return content; }
 bodyContentText = text:bodyContentChar+ { return text.join(''); }
 bodyContentChar = escaped / !tabStop char:. { return char; }
 
-escaped = '\\' char:[$\\] { return char; }
+escaped = '\\' char:. { return char; }
 tabStop = simpleTabStop / tabStopWithoutPlaceholder / tabStopWithPlaceholder
 simpleTabStop = '$' index:[0-9]+ {
   return { index: parseInt(index.join("")), content: [] };
@@ -15,7 +15,7 @@ tabStopWithPlaceholder = '${' index:[0-9]+ ':' content:placeholderContent '}' {
 }
 placeholderContent = content:(tabStop / variable / placeholderContentText)* { return content; }
 placeholderContentText = text:placeholderContentChar+ { return text.join(''); }
-placeholderContentChar = !tabStop !variable char:[^}] { return char; }
+placeholderContentChar = escaped / !tabStop !variable char:[^}] { return char; }
 
 variable = '${' variableContent '}' {
   return ''; // we eat variables and do nothing with them for now

--- a/spec/body-parser-spec.coffee
+++ b/spec/body-parser-spec.coffee
@@ -54,3 +54,16 @@ describe "Snippet Body Parser", ->
         content: []
       }
     ]
+
+  it "includes escaped right-braces", ->
+    bodyTree = BodyParser.parse """
+      snippet ${1:{\\}}
+    """
+
+    expect(bodyTree).toEqual [
+      "snippet ",
+      {
+        index: 1,
+        content: ["{}"]
+      }
+    ]


### PR DESCRIPTION
Aim to resolve #60.

To include } in your placeholder content selection, escape it with two \ :
```
it('${1:does something}' ${2:, function($3) {
    $4
\\}});
```