### PR TITLE
Fix detection of cursor movement within tab-stops

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -25,9 +25,8 @@ class SnippetExpansion
 
   cursorMoved: ({oldBufferPosition, newBufferPosition, textChanged}) ->
     return if @settingTabStop or textChanged
-    oldTabStops = @tabStopsForBufferPosition(oldBufferPosition)
-    newTabStops = @tabStopsForBufferPosition(newBufferPosition)
-    @destroy() unless _.intersection(oldTabStops, newTabStops).length
+    @destroy() unless @tabStopMarkers[@tabStopIndex].some (marker) ->
+      marker.getBufferRange().containsPoint(newBufferPosition)
 
   cursorDestroyed: -> @destroy() unless @settingTabStop
 
@@ -79,10 +78,6 @@ class SnippetExpansion
 
     @settingTabStop = false
     markerSelected
-
-  tabStopsForBufferPosition: (bufferPosition) ->
-    _.intersection(@tabStopMarkers[@tabStopIndex],
-      @editor.findMarkers(containsBufferPosition: bufferPosition))
 
   destroy: ->
     @subscriptions.dispose()


### PR DESCRIPTION
Marker events changed a little in Atom 0.200. This fixes cursor movement handling to work with the new contract. It also simplifies the logic for terminating snippet expansion to match the description in [the existing spec](https://github.com/atom/snippets/blob/master/spec/snippets-spec.coffee#L223):

> *[The snippet expansion is terminated]* when the cursor is moved beyond the bounds of the current tab stop.

Fixes #139
