### PR TITLE
Accept null snippets

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -181,6 +181,7 @@ module.exports =
         else if not body?
           snippetsByPrefix[prefix] = null
       atom.config.set('snippets', snippetsByPrefix, source: filePath, scopeSelector: selector)
+    return
 
   getBodyParser: ->
     @bodyParser ?= require './snippet-body-parser'

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -172,12 +172,14 @@ module.exports =
       snippetsByPrefix = {}
       for name, attributes of snippetsByName
         {prefix, body, bodyTree, description, descriptionMoreURL} = attributes
-        continue if typeof body isnt 'string'
 
-        # if `add` isn't called by the loader task (in specs for example), we need to parse the body
-        bodyTree ?= @getBodyParser().parse(body)
-        snippet = new Snippet({name, prefix, bodyTree, description, descriptionMoreURL, bodyText: body})
-        snippetsByPrefix[snippet.prefix] = snippet
+        if typeof body is 'string'
+          # if `add` isn't called by the loader task (in specs for example), we need to parse the body
+          bodyTree ?= @getBodyParser().parse(body) if typeof body is 'string'
+          snippet = new Snippet({name, prefix, bodyTree, description, descriptionMoreURL, bodyText: body})
+          snippetsByPrefix[snippet.prefix] = snippet
+        else if not body?
+          snippetsByPrefix[prefix] = null
       atom.config.set('snippets', snippetsByPrefix, source: filePath, scopeSelector: selector)
 
   getBodyParser: ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -43,6 +43,25 @@ describe "Snippets extension", ->
         snippetsInterface.insertSnippet("hello ${1:world}", editor)
         expect(editor.lineTextForBufferRow(0)).toBe "var hello world = function () {"
 
+  describe "when null snippets are present", ->
+    beforeEach ->
+      Snippets.add __filename,
+        '.source.js':
+          "some snippet":
+            prefix: "t1"
+            body: "this is a test"
+
+        '.source.js .nope':
+          "some snippet":
+            prefix: "t1"
+            body: null
+
+    it "overrides the less-specific defined snippet", ->
+      snippets = atom.config.get('snippets', scope: ['.source.js'])
+      expect(snippets['t1']).not.toBe null
+      snippets = atom.config.get('snippets', scope: ['.source.js .nope.not-today'])
+      expect(snippets['t1']).toBe null
+
   describe "when 'tab' is triggered on the editor", ->
     beforeEach ->
       Snippets.add __filename,


### PR DESCRIPTION
This will help fix the lang html issue. One caveat is that to null out a snippet, you need to have a prefix. This is because the snippets are stored in the config by prefix. 

The spec does a good job explaining the new functionality.

```coffee
describe "when null snippets are present", ->
  beforeEach ->
    Snippets.add __filename,
      '.source.js':
        "some snippet":
          prefix: "t1"
          body: "this is a test"

      '.source.js .nope':
        "some snippet":
          prefix: "t1"
          body: null

  it "overrides the less-specific defined snippet", ->
    snippets = atom.config.get('snippets', scope: ['.source.js'])
    expect(snippets['t1']).not.toBe null
    snippets = atom.config.get('snippets', scope: ['.source.js .nope.not-today'])
    expect(snippets['t1']).toBe null
```

cc @nathansobo @maxbrunsfeld 