### PR TITLE
Load snippets from core packages first

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -123,7 +123,8 @@ module.exports =
 
   loadPackageSnippets: (callback) ->
     packages = atom.packages.getLoadedPackages()
-    snippetsDirPaths = (path.join(pack.path, 'snippets') for pack in packages)
+    snippetsDirPaths = (path.join(pack.path, 'snippets') for pack in packages).sort (a, b) ->
+      if /\/app\.asar\/node_modules\//.test(a) then -1 else 1
     async.map snippetsDirPaths, @loadSnippetsDirectory.bind(this), (error, results) ->
       callback(_.extend({}, results...))
 

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -71,6 +71,23 @@ describe "Snippet Loading", ->
       expect(console.warn.calls.length).toBe 1
       expect(console.warn.mostRecentCall.args[0]).toMatch(/Error reading.*package-with-broken-snippets/)
 
+  describe "::loadPackageSnippets(callback)", ->
+
+    beforeEach ->
+      # simulate a list of packages where the javascript core package is returned at the end
+      jasmine.unspy(atom.packages, 'getLoadedPackages')
+      spyOn(atom.packages, 'getLoadedPackages').andReturn [
+        atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-snippets'))
+        atom.packages.loadPackage('language-javascript')
+      ]
+
+    it "returns core packages before other packages", ->
+      waitsFor "package to activate", (done) ->
+        atom.packages.activatePackage("snippets").then ({mainModule}) ->
+          mainModule.loadPackageSnippets (snippetSet) ->
+            expect(Object.keys(snippetSet)[0]).toMatch(/\/app\.asar\/node_modules\//)
+            done()
+
   describe "::onDidLoadSnippets(callback)", ->
     it "invokes listeners when all snippets are loaded", ->
       loadedCallback = null


### PR DESCRIPTION
Snippets from packages are currently loaded according to the order returned from `atom.packages.getLoadedPackages()`. However, core packages are always returned at the end of the list, making it impossible for another package to override snippets from a core package like `language-javascript`.

This pr sorts the results from `getLoadedPackages` so that snippets from core packages are loaded before.