### PR TITLE
:green_heart: Fix load core snippets first spec

### DIFF
--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -85,7 +85,7 @@ describe "Snippet Loading", ->
       waitsFor "package to activate", (done) ->
         atom.packages.activatePackage("snippets").then ({mainModule}) ->
           mainModule.loadPackageSnippets (snippetSet) ->
-            expect(Object.keys(snippetSet)[0]).toMatch(/\/app\.asar\/node_modules\//)
+            expect(Object.keys(snippetSet)[0]).toMatch(/language-javascript/)
             done()
 
   describe "::onDidLoadSnippets(callback)", ->


### PR DESCRIPTION
The spec shouldn't be dependent on the directory from which the snippets are loaded, since that is different depending on whether one is building Atom from source or installing it. Simply check that the first item is from the `language-javascript` package.

This wasn't failing on the snippets package, but is failing for OS X on Core and when run locally.