### PR TITLE
no longer rely on consolidateSelections to remove cursors in spec

### DIFF
--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -474,7 +474,7 @@ describe "Snippets extension", ->
         editor.setCursorScreenPosition([0, 0])
         editor.insertText('t9b')
         simulateTabKeyEvent()
-        editor.consolidateSelections()
+        editor.getCursors()[0].destroy()
         simulateTabKeyEvent()
 
         expect(editor.lineTextForBufferRow(1)).toEqual("without placeholder   ")
@@ -485,7 +485,7 @@ describe "Snippets extension", ->
         simulateTabKeyEvent()
         editor.insertText('test')
 
-        editor.consolidateSelections()
+        editor.getCursors()[0].destroy()
         editor.moveDown() # this should destroy the previous expansion
         editor.moveToBeginningOfLine()
 


### PR DESCRIPTION
Related to the PR on atom core atom/atom#8604

I have a PR on atom core that changes the behavior of consolidateSelections. That build failed because snippets is using that function to remove cursors in its spec.

This PR just removes the cursor manually in the spec - so as not to rely on consolidateSelections