### PR TITLE
Add explanation of how to escape curly brackets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,18 @@ You can also use multi-line syntax using `"""` for larger templates:
       }
     """
 ```
+
+### Escaping Characters
+
+Including a literal a closing brace inside the text provided by a snippet's tab stop will close
+that tab stop early. You need to escape it -- with *two* backslashes, like this:
+
+```coffee
+'body': """
+  ${1:function () {
+    statements;
+  \\}
+  this line is also included in the snippet tab;
+  }
+  """
+```

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ You can also use multi-line syntax using `"""` for larger templates:
 
 ### Escaping Characters
 
-Including a literal a closing brace inside the text provided by a snippet's tab stop will close
-that tab stop early. You need to escape it -- with *two* backslashes, like this:
+Including a literal closing brace inside the text provided by a snippet's tab stop will close
+that tab stop early. To prevent that, escape the brace with two backslashes, like so:
 
 ```coffee
 'body': """


### PR DESCRIPTION
I thought adding this to the README would be useful, after reading [issue 162](https://github.com/atom/snippets/issues/162).