### PR TITLE
:memo: changing "Open Your Snippets" location to File

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX or the _Edit > Open Your Snippets_ menu option if you're using Windows or Linux.
+To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX or the _File > Open Your Snippets_ menu option if you're using Windows or Linux.
 
 ## Snippet Format
 


### PR DESCRIPTION
readme currently lists that action under Edit, but it's under File on Atom 1.0.13 for Windows