### PR TITLE
Load snippets lazily

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -177,8 +177,9 @@ module.exports =
       unparsedSnippetsByPrefix = {}
       for name, attributes of snippetsByName
         {prefix, body} = attributes
+        attributes.name = name
         if typeof body is 'string'
-          unparsedSnippetsByPrefix[prefix] = _.extend({name}, attributes)
+          unparsedSnippetsByPrefix[prefix] = attributes
         else if not body?
           unparsedSnippetsByPrefix[prefix] = null
 

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -320,3 +320,4 @@ module.exports =
   provideSnippets: ->
     bundledSnippetsLoaded: => @loaded
     insertSnippet: @insert.bind(this)
+    snippetsByPrefixForScopes: @snippetsByPrefixForScopes.bind(this)

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -15,7 +15,7 @@ module.exports =
   activate: ->
     @userSnippetsPath = null
     @snippetIdCounter = 0
-    @snippetsCache = new Map
+    @parsedSnippetsById = new Map
     @scopedPropertyStore = new ScopedPropertyStore
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.addOpener (uri) =>
@@ -206,7 +206,7 @@ module.exports =
   clearSnippetsForPath: (path) ->
     for scopeSelector of @scopedPropertyStore.propertiesForSource(path)
       for prefix, attributes of @scopedPropertyStore.propertiesForSourceAndSelector(path, scopeSelector)
-        @snippetsCache.delete(attributes.id)
+        @parsedSnippetsById.delete(attributes.id)
 
       @scopedPropertyStore.removePropertiesForSourceAndSelector(path, scopeSelector)
 
@@ -219,12 +219,12 @@ module.exports =
 
       {id, name, body, bodyTree, description, descriptionMoreURL} = attributes
 
-      unless @snippetsCache.has(id)
+      unless @parsedSnippetsById.has(id)
         bodyTree ?= @getBodyParser().parse(body)
         snippet = new Snippet({id, name, prefix, bodyTree, description, descriptionMoreURL, bodyText: body})
-        @snippetsCache.set(id, snippet)
+        @parsedSnippetsById.set(id, snippet)
 
-      snippets[prefix] = @snippetsCache.get(id)
+      snippets[prefix] = @parsedSnippetsById.get(id)
     snippets
 
   priorityForSource: (source) ->

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -123,7 +123,7 @@ module.exports =
   handleUserSnippetsDidChange: ->
     userSnippetsPath = @getUserSnippetsPath()
     atom.config.transact =>
-      @clearUnparsedSnippetsForPath(userSnippetsPath)
+      @clearSnippetsForPath(userSnippetsPath)
       @loadSnippetsFile userSnippetsPath, (result) =>
         @add(userSnippetsPath, result)
 
@@ -203,9 +203,11 @@ module.exports =
     unparsedSnippets[selector] = {"snippets": value}
     @scopedPropertyStore.addProperties(path, unparsedSnippets, priority: @priorityForSource(path))
 
-  clearUnparsedSnippetsForPath: (path) ->
+  clearSnippetsForPath: (path) ->
     for scopeSelector of @scopedPropertyStore.propertiesForSource(path)
-      settings = @scopedPropertyStore.propertiesForSourceAndSelector(path, scopeSelector)
+      for prefix, attributes of @scopedPropertyStore.propertiesForSourceAndSelector(path, scopeSelector)
+        @snippetsCache.delete(attributes.id)
+
       @scopedPropertyStore.removePropertiesForSourceAndSelector(path, scopeSelector)
 
   parsedSnippetsForScopes: (scopeDescriptor) ->

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-{ScopeDescriptor, Emitter, Disposable, CompositeDisposable, File} = require 'atom'
+{Emitter, Disposable, CompositeDisposable, File} = require 'atom'
 _ = require 'underscore-plus'
 async = require 'async'
 CSON = require 'season'
@@ -181,6 +181,15 @@ module.exports =
       @storeUnparsedSnippetsByPrefix(snippetsByPrefix, filePath, selector)
     return
 
+  getScopeChain: (object) ->
+    scopesArray = object?.getScopesArray?()
+    scopesArray ?= Array.from(object)
+    scopesArray
+      .map (scope) ->
+        scope = ".#{scope}" unless scope[0] is '.'
+        scope
+      .join(' ')
+
   storeUnparsedSnippetsByPrefix: (value, path, selector) ->
     unparsedSnippets = {}
     unparsedSnippets[selector] = {"snippets": value}
@@ -192,8 +201,7 @@ module.exports =
       @scopedPropertyStore.removePropertiesForSourceAndSelector(path, scopeSelector)
 
   parsedSnippetsByPrefixForScope: (descriptor) ->
-    scopeDescriptor = ScopeDescriptor.fromObject(descriptor)
-    unparsedSnippetsByPrefix = @scopedPropertyStore.getPropertyValue(scopeDescriptor.getScopeChain(), "snippets")
+    unparsedSnippetsByPrefix = @scopedPropertyStore.getPropertyValue(@getScopeChain(descriptor), "snippets")
     unparsedSnippetsByPrefix ?= {}
     snippets = {}
     for prefix, attributes of unparsedSnippetsByPrefix

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -183,7 +183,7 @@ module.exports =
 
   getScopeChain: (object) ->
     scopesArray = object?.getScopesArray?()
-    scopesArray ?= Array.from(object)
+    scopesArray ?= object
     scopesArray
       .map (scope) ->
         scope = ".#{scope}" unless scope[0] is '.'

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -201,8 +201,8 @@ module.exports =
     snippetsAttributesByPrefix = @scopedPropertyStore.getPropertyValue(scopeDescriptor.getScopeChain(), "snippets")
     snippetsAttributesByPrefix ?= {}
     snippets = {}
-    for prefix, attributes of snippetsAttributesByPrefix when attributes?
-      continue if typeof attributes.body isnt 'string'
+    for prefix, attributes of snippetsAttributesByPrefix
+      continue if typeof attributes?.body isnt 'string'
 
       {name, body, bodyTree, description, descriptionMoreURL} = attributes
       bodyTree ?= @getBodyParser().parse(body)

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -5,7 +5,6 @@ async = require 'async'
 CSON = require 'season'
 fs = require 'fs-plus'
 ScopedPropertyStore = require 'scoped-property-store'
-{getValueAtKeyPath, setValueAtKeyPath} = require 'key-path-helpers'
 
 Snippet = require './snippet'
 SnippetExpansion = require './snippet-expansion'
@@ -183,13 +182,9 @@ module.exports =
     return
 
   storeUnparsedSnippetsByPrefix: (value, path, selector) ->
-    newValue = {}
-    setValueAtKeyPath(newValue, "snippets", value)
-    value = newValue
-
-    settingsBySelector = {}
-    settingsBySelector[selector] = value
-    @scopedPropertyStore.addProperties(path, settingsBySelector, priority: @priorityForSource(path))
+    unparsedSnippets = {}
+    unparsedSnippets[selector] = {"snippets": value}
+    @scopedPropertyStore.addProperties(path, unparsedSnippets, priority: @priorityForSource(path))
 
   clearUnparsedSnippetsForPath: (path) ->
     for scopeSelector of @scopedPropertyStore.propertiesForSource(path)

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -170,15 +170,15 @@ module.exports =
 
   add: (filePath, snippetsBySelector) ->
     for selector, snippetsByName of snippetsBySelector
-      snippetsByPrefix = {}
+      unparsedSnippetsByPrefix = {}
       for name, attributes of snippetsByName
         {prefix, body} = attributes
         if typeof body is 'string'
-          snippetsByPrefix[prefix] = _.extend({name}, attributes)
+          unparsedSnippetsByPrefix[prefix] = _.extend({name}, attributes)
         else if not body?
-          snippetsByPrefix[prefix] = null
+          unparsedSnippetsByPrefix[prefix] = null
 
-      @storeUnparsedSnippetsByPrefix(snippetsByPrefix, filePath, selector)
+      @storeUnparsedSnippets(unparsedSnippetsByPrefix, filePath, selector)
     return
 
   getScopeChain: (object) ->
@@ -190,7 +190,7 @@ module.exports =
         scope
       .join(' ')
 
-  storeUnparsedSnippetsByPrefix: (value, path, selector) ->
+  storeUnparsedSnippets: (value, path, selector) ->
     unparsedSnippets = {}
     unparsedSnippets[selector] = {"snippets": value}
     @scopedPropertyStore.addProperties(path, unparsedSnippets, priority: @priorityForSource(path))
@@ -200,8 +200,8 @@ module.exports =
       settings = @scopedPropertyStore.propertiesForSourceAndSelector(path, scopeSelector)
       @scopedPropertyStore.removePropertiesForSourceAndSelector(path, scopeSelector)
 
-  parsedSnippetsByPrefixForScope: (descriptor) ->
-    unparsedSnippetsByPrefix = @scopedPropertyStore.getPropertyValue(@getScopeChain(descriptor), "snippets")
+  parsedSnippetsForScopes: (scopeDescriptor) ->
+    unparsedSnippetsByPrefix = @scopedPropertyStore.getPropertyValue(@getScopeChain(scopeDescriptor), "snippets")
     unparsedSnippetsByPrefix ?= {}
     snippets = {}
     for prefix, attributes of unparsedSnippetsByPrefix
@@ -268,7 +268,7 @@ module.exports =
     longestPrefixMatch
 
   getSnippets: (editor) ->
-    @parsedSnippetsByPrefixForScope(editor.getLastCursor().getScopeDescriptor())
+    @parsedSnippetsForScopes(editor.getLastCursor().getScopeDescriptor())
 
   snippetToExpandUnderCursor: (editor) ->
     return false unless editor.getLastSelection().isEmpty()
@@ -323,4 +323,4 @@ module.exports =
   provideSnippets: ->
     bundledSnippetsLoaded: => @loaded
     insertSnippet: @insert.bind(this)
-    snippetsByPrefixForScopes: @parsedSnippetsByPrefixForScope.bind(this)
+    snippetsForScopes: @parsedSnippetsForScopes.bind(this)

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -13,6 +13,7 @@ module.exports =
   loaded: false
 
   activate: ->
+    @userSnippetsPath = null
     @scopedPropertyStore = new ScopedPropertyStore
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.addOpener (uri) =>
@@ -58,8 +59,11 @@ module.exports =
     atom.config.transact => @subscriptions.dispose()
 
   getUserSnippetsPath: ->
-    userSnippetsPath = CSON.resolve(path.join(atom.getConfigDirPath(), 'snippets'))
-    userSnippetsPath ? path.join(atom.getConfigDirPath(), 'snippets.cson')
+    return @userSnippetsPath if @userSnippetsPath?
+
+    @userSnippetsPath = CSON.resolve(path.join(atom.getConfigDirPath(), 'snippets'))
+    @userSnippetsPath ?= path.join(atom.getConfigDirPath(), 'snippets.cson')
+    @userSnippetsPath
 
   loadAll: (callback) ->
     @loadBundledSnippets (bundledSnippets) =>

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -334,7 +334,11 @@ module.exports =
       snippet = new Snippet({name: '__anonymous', prefix: '', bodyTree, bodyText: snippet})
     new SnippetExpansion(snippet, editor, cursor, this)
 
+  getUnparsedSnippets: ->
+    _.deepClone(@scopedPropertyStore.propertySets)
+
   provideSnippets: ->
     bundledSnippetsLoaded: => @loaded
     insertSnippet: @insert.bind(this)
     snippetsForScopes: @parsedSnippetsForScopes.bind(this)
+    getUnparsedSnippets: @getUnparsedSnippets.bind(this)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "async": "~0.2.6",
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "^2.0.0",
-    "key-path-helpers": "^0.4.0",
     "loophole": "^1",
     "pegjs": "~0.8.0",
     "scoped-property-store": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "async": "~0.2.6",
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "^2.0.0",
+    "key-path-helpers": "^0.4.0",
     "loophole": "^1",
     "pegjs": "~0.8.0",
+    "scoped-property-store": "^0.17.0",
     "season": "^5.0.4",
     "temp": "~0.8.0",
     "underscore-plus": "^1.0.0"

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -34,14 +34,14 @@ describe "Snippet Loading", ->
     activateSnippetsPackage()
 
     runs ->
-      jsonSnippet = atom.config.get('snippets.snip', scope: ['.source.json'])
+      jsonSnippet = snippetsModule.snippetsByPrefixForScopes(['.source.json'])['snip']
       expect(jsonSnippet.name).toBe 'Atom Snippet'
       expect(jsonSnippet.prefix).toBe 'snip'
       expect(jsonSnippet.body).toContain '"prefix":'
       expect(jsonSnippet.body).toContain '"body":'
       expect(jsonSnippet.tabStops.length).toBeGreaterThan(0)
 
-      csonSnippet = atom.config.get('snippets.snip', scope: ['.source.coffee'])
+      csonSnippet = snippetsModule.snippetsByPrefixForScopes(['.source.coffee'])['snip']
       expect(csonSnippet.name).toBe 'Atom Snippet'
       expect(csonSnippet.prefix).toBe 'snip'
       expect(csonSnippet.body).toContain "'prefix':"
@@ -52,11 +52,11 @@ describe "Snippet Loading", ->
     activateSnippetsPackage()
 
     runs ->
-      snippet = atom.config.get('snippets.test', scope: ['.test'])
+      snippet = snippetsModule.snippetsByPrefixForScopes(['.test'])['test']
       expect(snippet.prefix).toBe 'test'
       expect(snippet.body).toBe 'testing 123'
 
-      snippet = atom.config.get('snippets.testd', scope: ['.test'])
+      snippet = snippetsModule.snippetsByPrefixForScopes(['.test'])['testd']
       expect(snippet.prefix).toBe 'testd'
       expect(snippet.body).toBe 'testing 456'
       expect(snippet.description).toBe 'a description'
@@ -85,7 +85,8 @@ describe "Snippet Loading", ->
       activateSnippetsPackage()
 
       runs ->
-        expect(atom.config.get("snippets.log", scope: ['.source.js']).body).toBe "from-a-community-package"
+        snippet = snippetsModule.snippetsByPrefixForScopes(['.source.js'])['log']
+        expect(snippet.body).toBe "from-a-community-package"
 
   describe "::onDidLoadSnippets(callback)", ->
     it "invokes listeners when all snippets are loaded", ->
@@ -116,7 +117,7 @@ describe "Snippet Loading", ->
       snippet = null
 
       waitsFor ->
-        snippet = atom.config.get('snippets.foo', scope: ['.foo'])
+        snippet = snippetsModule.snippetsByPrefixForScopes(['.foo'])['foo']
 
       runs ->
         expect(snippet.name).toBe 'foo snippet'
@@ -137,13 +138,14 @@ describe "Snippet Loading", ->
         """
 
         waitsFor "snippets to be changed", ->
-          atom.config.get('snippets.foo', scope: ['.foo'])?.body is 'bar2'
+          snippet = snippetsModule.snippetsByPrefixForScopes(['.foo'])['foo']
+          snippet?.body is 'bar2'
 
         runs ->
           fs.writeFileSync path.join(configDirPath, 'snippets.json'), ""
 
         waitsFor "snippets to be removed", ->
-          not atom.config.get('snippets.foo', scope: ['.foo'])?
+          not snippetsModule.snippetsByPrefixForScopes(['.foo'])['foo']
 
   describe "when ~/.atom/snippets.cson exists", ->
     beforeEach ->
@@ -159,7 +161,7 @@ describe "Snippet Loading", ->
       snippet = null
 
       waitsFor ->
-        snippet = atom.config.get('snippets.foo', scope: ['.foo'])
+        snippet = snippetsModule.snippetsByPrefixForScopes(['.foo'])['foo']
 
       runs ->
         expect(snippet.name).toBe 'foo snippet'
@@ -176,13 +178,15 @@ describe "Snippet Loading", ->
         """
 
         waitsFor "snippets to be changed", ->
-          atom.config.get('snippets.foo', scope: ['.foo'])?.body is 'bar2'
+          snippet = snippetsModule.snippetsByPrefixForScopes(['.foo'])['foo']
+          snippet?.body is 'bar2'
 
         runs ->
           fs.writeFileSync path.join(configDirPath, 'snippets.cson'), ""
 
         waitsFor "snippets to be removed", ->
-          not atom.config.get('snippets.foo', scope: ['.foo'])?
+          snippet = snippetsModule.snippetsByPrefixForScopes(['.foo'])['foo']
+          not snippet?
 
   it "notifies the user when the user snippets file cannot be loaded", ->
     fs.writeFileSync path.join(configDirPath, 'snippets.cson'), """

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -34,14 +34,14 @@ describe "Snippet Loading", ->
     activateSnippetsPackage()
 
     runs ->
-      jsonSnippet = snippetsService.snippetsByPrefixForScopes(['.source.json'])['snip']
+      jsonSnippet = snippetsService.snippetsForScopes(['.source.json'])['snip']
       expect(jsonSnippet.name).toBe 'Atom Snippet'
       expect(jsonSnippet.prefix).toBe 'snip'
       expect(jsonSnippet.body).toContain '"prefix":'
       expect(jsonSnippet.body).toContain '"body":'
       expect(jsonSnippet.tabStops.length).toBeGreaterThan(0)
 
-      csonSnippet = snippetsService.snippetsByPrefixForScopes(['.source.coffee'])['snip']
+      csonSnippet = snippetsService.snippetsForScopes(['.source.coffee'])['snip']
       expect(csonSnippet.name).toBe 'Atom Snippet'
       expect(csonSnippet.prefix).toBe 'snip'
       expect(csonSnippet.body).toContain "'prefix':"
@@ -52,11 +52,11 @@ describe "Snippet Loading", ->
     activateSnippetsPackage()
 
     runs ->
-      snippet = snippetsService.snippetsByPrefixForScopes(['.test'])['test']
+      snippet = snippetsService.snippetsForScopes(['.test'])['test']
       expect(snippet.prefix).toBe 'test'
       expect(snippet.body).toBe 'testing 123'
 
-      snippet = snippetsService.snippetsByPrefixForScopes(['.test'])['testd']
+      snippet = snippetsService.snippetsForScopes(['.test'])['testd']
       expect(snippet.prefix).toBe 'testd'
       expect(snippet.body).toBe 'testing 456'
       expect(snippet.description).toBe 'a description'
@@ -85,7 +85,7 @@ describe "Snippet Loading", ->
       activateSnippetsPackage()
 
       runs ->
-        snippet = snippetsService.snippetsByPrefixForScopes(['.source.js'])['log']
+        snippet = snippetsService.snippetsForScopes(['.source.js'])['log']
         expect(snippet.body).toBe "from-a-community-package"
 
   describe "::onDidLoadSnippets(callback)", ->
@@ -117,7 +117,7 @@ describe "Snippet Loading", ->
       snippet = null
 
       waitsFor ->
-        snippet = snippetsService.snippetsByPrefixForScopes(['.foo'])['foo']
+        snippet = snippetsService.snippetsForScopes(['.foo'])['foo']
 
       runs ->
         expect(snippet.name).toBe 'foo snippet'
@@ -138,14 +138,14 @@ describe "Snippet Loading", ->
         """
 
         waitsFor "snippets to be changed", ->
-          snippet = snippetsService.snippetsByPrefixForScopes(['.foo'])['foo']
+          snippet = snippetsService.snippetsForScopes(['.foo'])['foo']
           snippet?.body is 'bar2'
 
         runs ->
           fs.writeFileSync path.join(configDirPath, 'snippets.json'), ""
 
         waitsFor "snippets to be removed", ->
-          not snippetsService.snippetsByPrefixForScopes(['.foo'])['foo']
+          not snippetsService.snippetsForScopes(['.foo'])['foo']
 
   describe "when ~/.atom/snippets.cson exists", ->
     beforeEach ->
@@ -161,7 +161,7 @@ describe "Snippet Loading", ->
       snippet = null
 
       waitsFor ->
-        snippet = snippetsService.snippetsByPrefixForScopes(['.foo'])['foo']
+        snippet = snippetsService.snippetsForScopes(['.foo'])['foo']
 
       runs ->
         expect(snippet.name).toBe 'foo snippet'
@@ -178,14 +178,14 @@ describe "Snippet Loading", ->
         """
 
         waitsFor "snippets to be changed", ->
-          snippet = snippetsService.snippetsByPrefixForScopes(['.foo'])['foo']
+          snippet = snippetsService.snippetsForScopes(['.foo'])['foo']
           snippet?.body is 'bar2'
 
         runs ->
           fs.writeFileSync path.join(configDirPath, 'snippets.cson'), ""
 
         waitsFor "snippets to be removed", ->
-          snippet = snippetsService.snippetsByPrefixForScopes(['.foo'])['foo']
+          snippet = snippetsService.snippetsForScopes(['.foo'])['foo']
           not snippet?
 
   it "notifies the user when the user snippets file cannot be loaded", ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -81,8 +81,8 @@ describe "Snippets extension", ->
 
     it "overrides the less-specific defined snippet", ->
       snippets = Snippets.provideSnippets()
-      expect(snippets.snippetsByPrefixForScopes(['.source.js'])['t1']).toBeTruthy()
-      expect(snippets.snippetsByPrefixForScopes(['.source.js .nope.not-today'])['t1']).toBeFalsy()
+      expect(snippets.snippetsForScopes(['.source.js'])['t1']).toBeTruthy()
+      expect(snippets.snippetsForScopes(['.source.js .nope.not-today'])['t1']).toBeFalsy()
 
   describe "when 'tab' is triggered on the editor", ->
     beforeEach ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -51,7 +51,7 @@ describe "Snippets extension", ->
     snippets = atom.packages.getActivePackage('snippets').mainModule
 
     invalidSnippets = null
-    spyOn(atom.config, 'get').andCallFake -> invalidSnippets
+    spyOn(snippets.scopedPropertyStore, 'getPropertyValue').andCallFake -> invalidSnippets
     expect(snippets.getSnippets(editor)).toEqual {}
 
     invalidSnippets = 'test'

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -177,6 +177,42 @@ describe "Snippets extension", ->
               $0one${1} ${2:two} three${3}
             """
 
+    it "parses snippets once, reusing cached ones on subsequent queries", ->
+      spyOn(Snippets, "getBodyParser").andCallThrough()
+
+      editor.insertText("t1")
+      simulateTabKeyEvent()
+
+      expect(Snippets.getBodyParser).toHaveBeenCalled()
+      expect(editor.lineTextForBufferRow(0)).toBe "this is a testvar quicksort = function () {"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 14]
+
+      Snippets.getBodyParser.reset()
+
+      editor.setText("")
+      editor.insertText("t1")
+      simulateTabKeyEvent()
+
+      expect(Snippets.getBodyParser).not.toHaveBeenCalled()
+      expect(editor.lineTextForBufferRow(0)).toBe "this is a test"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 14]
+
+      Snippets.getBodyParser.reset()
+
+      Snippets.add __filename,
+        ".source.js":
+          "invalidate previous snippet":
+            prefix: "t1"
+            body: "new snippet"
+
+      editor.setText("")
+      editor.insertText("t1")
+      simulateTabKeyEvent()
+
+      expect(Snippets.getBodyParser).toHaveBeenCalled()
+      expect(editor.lineTextForBufferRow(0)).toBe "new snippet"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 11]
+
     describe "when the snippet body is invalid or missing", ->
       it "does not register the snippet", ->
         editor.setText('')

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -80,7 +80,7 @@ describe "Snippets extension", ->
             body: null
 
     it "overrides the less-specific defined snippet", ->
-      snippets = atom.packages.getActivePackage('snippets').mainModule
+      snippets = Snippets.provideSnippets()
       expect(snippets.snippetsByPrefixForScopes(['.source.js'])['t1']).toBeTruthy()
       expect(snippets.snippetsByPrefixForScopes(['.source.js .nope.not-today'])['t1']).toBeFalsy()
 

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -80,10 +80,9 @@ describe "Snippets extension", ->
             body: null
 
     it "overrides the less-specific defined snippet", ->
-      snippets = atom.config.get('snippets', scope: ['.source.js'])
-      expect(snippets['t1']).not.toBe null
-      snippets = atom.config.get('snippets', scope: ['.source.js .nope.not-today'])
-      expect(snippets['t1']).toBe null
+      snippets = atom.packages.getActivePackage('snippets').mainModule
+      expect(snippets.snippetsByPrefixForScopes(['.source.js'])['t1']).toBeTruthy()
+      expect(snippets.snippetsByPrefixForScopes(['.source.js .nope.not-today'])['t1']).toBeFalsy()
 
   describe "when 'tab' is triggered on the editor", ->
     beforeEach ->


### PR DESCRIPTION
Our current situation on master looks like the following during startup:

![screen shot 2015-11-05 at 15 46 51](https://cloud.githubusercontent.com/assets/482957/10971802/692e6cba-83d6-11e5-9014-8d549cdfb3e9.png)

Out of 3s, ~410ms are spent in loading snippets:

![screen shot 2015-11-05 at 15 48 01](https://cloud.githubusercontent.com/assets/482957/10971809/714f8a3c-83d6-11e5-86a4-6f06c5f066f5.png)

Although this doesn't synchronously affect Atom's initialization (i.e. `window.onload`), it has an heavy impact on user experience. Indeed, trying to disable the snippets package results in a more fluid and responsive startup.

The idea with this PR is to avoid doing all the work of parsing snippets upfront and to defer it to the last possible moment. In the past, other packages relied on `atom.config.get` to access loaded snippets: because of configuration being eager by design, we couldn't afford this anymore and we've provided a service instead for other packages to use in order to introduce laziness.

The bad news is that this will be a breaking change, whereas the good news is that snippets take ~30ms to be loaded, thus not getting in the way of other important tasks such as _background_ tokenization, etc. Any ideas on how to handle this? I think that just :arrow_up: bumping the major version could be fine here, because the only package I have found which currently uses snippets that way is `autocomplete-snippets` and I am going to update it shortly.

Also, please note that I ended up not implementing a cache mechanism for parsed snippets, as the amount of parsing we do now is quite minimal and it doesn't seem to affect responsiveness on each keystroke.

/cc: @nathansobo @maxbrunsfeld @atom/feedback