### PR TITLE
:penguin: Fixed documentation for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OS X, or the _File > Open Your Snippets_ menu option if you're using Windows,using Windows, or the _Edit > Open Your Snippets_ menu option if you are using Linux.
+To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OS X, or the _File > Open Your Snippets_ menu option if you're using Windows, or the _Edit > Open Your Snippets_ menu option if you are using Linux.
 
 ## Snippet Format
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX, or the _File > Open Your Snippets_ menu option if you're using Windows, use the _Edit > Open Your Snippets_ menu option if you are using a Linux based operating system.
+To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX, or the _File > Open Your Snippets_ menu option if you're using Windows, use _Edit > Open Your Snippets if you are using Linux.
 
 ## Snippet Format
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX, or the _File > Open Your Snippets_ menu option if you're using Windows, use _Edit > Open Your Snippets_ if you are using Linux.
+To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OS X, or the _File > Open Your Snippets_ menu option if you're using Windows,using Windows, or the _Edit > Open Your Snippets_ menu option if you are using Linux.
 
 ## Snippet Format
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX or the _File > Open Your Snippets_ menu option if you're using Windows or Linux.
+To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX, or the _File > Open Your Snippets_ menu option if you're using Windows, use the _Edit > Open Your Snippets_ menu option if you are using a Linux based operating system.
 
 ## Snippet Format
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Expand snippets matching the current prefix with `tab` in Atom.
 
-To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX, or the _File > Open Your Snippets_ menu option if you're using Windows, use _Edit > Open Your Snippets if you are using Linux.
+To add your own snippets, select the _Atom > Open Your Snippets_ menu option if you're using OSX, or the _File > Open Your Snippets_ menu option if you're using Windows, use _Edit > Open Your Snippets_ if you are using Linux.
 
 ## Snippet Format
 


### PR DESCRIPTION
Before the instructions for Linux were the same as for windows, which did not accurately describe the situation in Linux. I created issue #183 to describe this problem earlier. I searched through the project for other incorrect references of how to open the snippets file, but I couldn't find any. I would be willing to fix other instances of this problem if they exist.