### PR TITLE
Added more formatting options for snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These parameters are meant to provide extra information about your snippet to [a
 
 * `leftLabel` will add text to the left part of the autocomplete results box.
 * `leftLabelHTML` will overwrite what's in `leftLabel` and allow you to use a bit of CSS such as `color`.
-* `rightLabelHTML`. By default, in th right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.
+* `rightLabelHTML`. By default, in the right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.
 * `description` will add text to a description box under the autocomplete results list.
 * `descriptionMoreURL` URL to the documentation of the snippet.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ console.log("crash");
 The string `"crash"` would be initially selected and pressing tab again would
 place the cursor after the `;`
 
+### Optional parameters
+These parameters are meant to provide extra information about your snippet to [autocomplete-plus](https://github.com/atom/autocomplete-plus/wiki/Provider-API).
+
+* `leftLabel` will add text to the left part of the autocomplete results box.
+* `leftLabelHTML` will overwrite what's in `leftLabel` and allow you to use a bit of CSS such as `color`.
+* `rightLabelHTML`. By default, in th right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.
+* `description` will add text to a description box under the autocomplete results list.
+* `descriptionMoreURL` URL to the documentation of the snippet.
+
+![autocomplete-description](http://i.imgur.com/cvI2lOq.png)
+
+Example:
+```coffee
+'.source.js':
+  'console.log':
+    'prefix': 'log'
+    'body': 'console.log(${1:"crash"});$2'
+    'description': 'Output data to the console'
+    'rightLabelHTML': '<span style="color:#ff0">JS</span>'
+```
+
 ### Determining the correct scope for a snippet
 
 The outmost key of a snippet is the "scope" that you want the descendent snippets

--- a/lib/snippet.coffee
+++ b/lib/snippet.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore-plus'
 
 module.exports =
 class Snippet
-  constructor: ({@name, @prefix, @bodyText, @description, @descriptionMoreURL, bodyTree}) ->
+  constructor: ({@name, @prefix, @bodyText, @description, @descriptionMoreURL, @rightLabelHTML, @leftLabel, @leftLabelHTML, bodyTree}) ->
     @body = @extractTabStops(bodyTree)
 
   extractTabStops: (bodyTree) ->

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -217,11 +217,11 @@ module.exports =
     for prefix, attributes of unparsedSnippetsByPrefix
       continue if typeof attributes?.body isnt 'string'
 
-      {id, name, body, bodyTree, description, descriptionMoreURL} = attributes
+      {id, name, body, bodyTree, description, descriptionMoreURL, rightLabelHTML, leftLabel, leftLabelHTML} = attributes
 
       unless @parsedSnippetsById.has(id)
         bodyTree ?= @getBodyParser().parse(body)
-        snippet = new Snippet({id, name, prefix, bodyTree, description, descriptionMoreURL, bodyText: body})
+        snippet = new Snippet({id, name, prefix, bodyTree, description, descriptionMoreURL, rightLabelHTML, leftLabel, leftLabelHTML, bodyText: body})
         @parsedSnippetsById.set(id, snippet)
 
       snippets[prefix] = @parsedSnippetsById.get(id)

--- a/spec/fixtures/package-with-snippets/snippets/test.cson
+++ b/spec/fixtures/package-with-snippets/snippets/test.cson
@@ -7,6 +7,15 @@
     body: "testing 456"
     description: "a description"
     descriptionMoreURL: "http://google.com"
+  "Test Snippet With A Label On The Left":
+    prefix: "testlabelleft"
+    body: "testing 456"
+    leftLabel: "a label"
+  "Test Snippet With HTML Labels":
+    prefix: "testhtmllabels"
+    body: "testing 456"
+    leftLabelHTML: "<span style=\"color:red\">Label</span>"
+    rightLabelHTML: "<span style=\"color:white\">Label</span>"
 
 ".source.js":
   "Overrides a core package's snippet":

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -62,6 +62,17 @@ describe "Snippet Loading", ->
       expect(snippet.description).toBe 'a description'
       expect(snippet.descriptionMoreURL).toBe 'http://google.com'
 
+      snippet = snippetsService.snippetsForScopes(['.test'])['testlabelleft']
+      expect(snippet.prefix).toBe 'testlabelleft'
+      expect(snippet.body).toBe 'testing 456'
+      expect(snippet.leftLabel).toBe 'a label'
+
+      snippet = snippetsService.snippetsForScopes(['.test'])['testhtmllabels']
+      expect(snippet.prefix).toBe 'testhtmllabels'
+      expect(snippet.body).toBe 'testing 456'
+      expect(snippet.leftLabelHTML).toBe '<span style=\"color:red\">Label</span>'
+      expect(snippet.rightLabelHTML).toBe '<span style=\"color:white\">Label</span>'
+
   it "logs a warning if package snippets files cannot be parsed", ->
     activateSnippetsPackage()
 


### PR DESCRIPTION
When working on a snippet I was wondering how other packages formatted the results in the autocomplete list. So I found the `autocomplete-plus` API can accept [more parameters for formatting the results](https://github.com/atom/autocomplete-plus/wiki/Provider-API).

> `leftLabel` (optional): This is shown before the suggestion. Useful for return values.
`leftLabelHTML` (optional): Use this instead of leftLabel if you want to use html for the left label.
`rightLabel` (optional): An indicator (e.g. function, variable) denoting the "kind" of suggestion this represents
`rightLabelHTML` (optional): Use this instead of rightLabel if you want to use html for the right label.

I thought it would be awesome to be able to visually format results for snippets too, so I have added those properties in the Snippet class so that you could add those in the cson files that define snippets.

The idea is to read those optional properties from the cson file and provide them to [autocomplete-snippets](https://github.com/atom/autocomplete-snippets) which in turn will deliver those results to autocomplete-plus.

**Additions to the Snippet class** (All parameters are optional)
* rightLabelHTML
* leftLabel
* leftLabelHTML

I haven't added rightLabel because `autocomplete-snippets` uses the `name` of the snippet to fill that and  is what all current snippets use to display some info.

I have also worked on `autocomplete-snippets` locally, but I will wait for this pull request to be accepted before submitting it there.