### PR TITLE
Add a settings view where one can disable snippets for certain packages

### DIFF
--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -48,6 +48,13 @@ describe "Snippet Loading", ->
       expect(csonSnippet.body).toContain "'body':"
       expect(csonSnippet.tabStops.length).toBeGreaterThan(0)
 
+   it "doesn't load the snippet files from disabled snippet package", ->
+    atom.config.set "snippets.package-with-snippets", false
+    activateSnippetsPackage()
+
+    runs ->
+      expect(snippetsService.snippetsForScopes(['.source.js'])).toEqual({})
+
   it "loads non-hidden snippet files from atom packages with snippets directories", ->
     activateSnippetsPackage()
 

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -48,7 +48,7 @@ describe "Snippet Loading", ->
       expect(csonSnippet.body).toContain "'body':"
       expect(csonSnippet.tabStops.length).toBeGreaterThan(0)
 
-   it "doesn't load the snippet files from disabled snippet package", ->
+  it "doesn't load the snippet files from disabled snippet package", ->
     atom.config.set "snippets.package-with-snippets", false
     activateSnippetsPackage()
 


### PR DESCRIPTION
I know it does look kind of hacky, but this is the way it should be done I think. I am yet to dive deeper so we can reload without restarting it, maybe be just fully reloading all snippets. Made this because of this issue #55
