### PR TITLE
Remove unused variables and fix references to fields

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -1,4 +1,3 @@
-_ = require 'underscore-plus'
 {CompositeDisposable} = require 'atom'
 
 module.exports =
@@ -14,14 +13,14 @@ class SnippetExpansion
 
     @editor.transact =>
       newRange = @editor.transact =>
-        @cursor.selection.insertText(snippet.body, autoIndent: false)
-      if snippet.tabStops.length > 0
+        @cursor.selection.insertText(@snippet.body, autoIndent: false)
+      if @snippet.tabStops.length > 0
         @subscriptions.add @cursor.onDidChangePosition (event) => @cursorMoved(event)
         @subscriptions.add @cursor.onDidDestroy => @cursorDestroyed()
-        @placeTabStopMarkers(startPosition, snippet.tabStops)
+        @placeTabStopMarkers(startPosition, @snippet.tabStops)
         @snippets.addExpansion(@editor, this)
         @editor.normalizeTabsInBufferRange(newRange)
-      @indentSubsequentLines(startPosition.row, snippet) if snippet.lineCount > 1
+      @indentSubsequentLines(startPosition.row, @snippet) if @snippet.lineCount > 1
 
   cursorMoved: ({oldBufferPosition, newBufferPosition, textChanged}) ->
     return if @settingTabStop or textChanged

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -485,7 +485,6 @@ describe "Snippets extension", ->
 
     describe "when snippet contains tabstops with or without placeholder", ->
       it "should create two markers", ->
-        markerCountBefore = editor.getMarkerCount()
         editor.setCursorScreenPosition([0, 0])
         editor.insertText('t8')
         simulateTabKeyEvent()


### PR DESCRIPTION
Removed some unused variables and improved forward compatibility with coffee-script >=1.9.0

Similar case to atom/autocomplete-plus#768