### PR TITLE
Don’t add pane items in the `atom://.atom/snippets` opener callback

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -20,7 +20,7 @@ module.exports =
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.addOpener (uri) =>
       if uri is 'atom://.atom/snippets'
-        atom.workspace.open(@getUserSnippetsPath())
+        atom.workspace.openTextFile(@getUserSnippetsPath())
 
     @loadAll()
     @watchUserSnippets (watchDisposable) =>


### PR DESCRIPTION
Using `openTextFile` just creates an editor without adding it as a pane item, permitting the in-progress `open` call to determine where the item is placed. This ensures options like `{split: ‘left’}` work correctly when opening this URI.