### PR TITLE
Define default ending tab stop at the end of the snippet

### DIFF
--- a/lib/snippet.coffee
+++ b/lib/snippet.coffee
@@ -30,6 +30,12 @@ class Snippet
             column = nextLine.length
 
     extractTabStops(bodyTree)
+    # If tab stop for end has not been explicitly defined and last tab stop does not include end of snippet,
+    # then the ending tab stop is placed at the end of the snippet.
+    snippetEnd = new Range([row, column], [row, column])
+    lastIndex = index for index of tabStopsByIndex
+    tabStopsByIndex[Infinity] = [snippetEnd] if lastIndex? and lastIndex isnt 'Infinity' and not tabStopsByIndex[lastIndex][0].isEqual(snippetEnd)
+
     @lineCount = row + 1
     @tabStops = []
     for index in _.keys(tabStopsByIndex).sort(((arg1, arg2) -> arg1-arg2))

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -654,6 +654,14 @@ describe "Snippets extension", ->
           expect(editor.lineTextForBufferRow(7)).toBe "    }one t1 three"
           expect(editor.lineTextForBufferRow(12)).toBe "};one t1 three"
 
+    describe "when the snippet does not explicitly define an end tab stop", ->
+      it "sets ending tab stop to the end of snippet", ->
+        editor.setCursorScreenPosition([2, 0])
+        editor.insertText('t3')
+        simulateTabKeyEvent()
+        simulateTabKeyEvent()
+        expect(editor.getSelectedBufferRange()).toEqual [[4, 0], [4, 0]]
+
   describe "when atom://.atom/snippets is opened", ->
     it "opens ~/.atom/snippets.cson", ->
       jasmine.unspy(Snippets, 'getUserSnippetsPath')


### PR DESCRIPTION
[TextMate manual](https://manual.macromates.com/en/snippets#tab_stops) specifies that if no ending tab stop has been defined explicitly, it should be added to the end of snippet:
> If you do not explicitly set `$0`, the caret will be at the end of the snippet.

For tab stops that do not contain a placeholder, this is behavior wise fine (but will not follow spec), but if the last defined tab stop happens to be a placeholder that is not being replaced, this happens (does not have to be necessarily at the end of the snippet):

![without](https://user-images.githubusercontent.com/1017132/28503497-ae50e6e2-7010-11e7-871b-4b5341a494b1.gif)

This pull request checks after processing the tab stops whether the end tab stop is defined (`$0`) or the last tab stop is already at the end. Otherwise it will include a zero-width end stop to the end of the snippet. TextMate only checks the first condition, second condition was added as means of maintaining compatibility with [_incorrectly-written_](https://github.com/atom/snippets/blob/17e4de99abac277a277b9a2644e84fd3bb6e3d22/lib/snippets.cson#L12) end-stops for now. Perhaps this should be presented as warning now and removed after a couple of releases.

![with](https://user-images.githubusercontent.com/1017132/28503551-1d0a4000-7012-11e7-8bd3-5cc05fc47487.gif)

This however does not fix the case where the explicitly defined end tab stop is a placeholder (`${0:placeholder}`), which will behave as the first image. TextMate in this case simply overwrites it with a tab, as that is the default behavior of selected text + tab. Atom's behavior of indenting the whole line when any character is selected, does not work very well together with this. Split into atom/atom#15096

Attempt to fix this issue revealed a regression in a test that does not sufficiently cover the regression it was supposed to prevent, which I do not know how to fix. Namely test for `t6` fails, which expands the snippet and then calls undo, which deletes all expanded text up to the zero-width end tab stop, which still exists. Calling tab again does not expand `t6`, but jumps to the position of that end tab stop. Without this pull request, but explicitly defining `$#` (can be any number) at the beginning/end of that snippet will fail the test as well. Split into #261 

It should be obvious that I am not expecting this pull request to be merged before these issues have been solved.
  