### PR TITLE
Make the bundled snippets work when the package is snapshotted

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,13 @@
+/** @babel */
+
+import path from 'path'
+
+export function getPackageRoot() {
+  const {resourcePath} = atom.getLoadSettings()
+  const currentFileWasRequiredFromSnapshot = !path.isAbsolute(__dirname)
+  if (currentFileWasRequiredFromSnapshot) {
+    return path.join(resourcePath, 'node_modules', 'snippets')
+  } else {
+    return path.resolve(__dirname, '..')
+  }
+}

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -8,6 +8,7 @@ ScopedPropertyStore = require 'scoped-property-store'
 
 Snippet = require './snippet'
 SnippetExpansion = require './snippet-expansion'
+{getPackageRoot} = require './helpers'
 
 module.exports =
   loaded: false
@@ -78,7 +79,7 @@ module.exports =
           @doneLoading()
 
   loadBundledSnippets: (callback) ->
-    bundledSnippetsPath = CSON.resolve(path.join(__dirname, 'snippets'))
+    bundledSnippetsPath = CSON.resolve(path.join(getPackageRoot(), 'lib', 'snippets'))
     @loadSnippetsFile bundledSnippetsPath, (snippets) ->
       snippetsByPath = {}
       snippetsByPath[bundledSnippetsPath] = snippets


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Add the function `getPackageRoot` and use it to calculate the path to `snippets.{cson,json}`.

I had to manually apply the changes to an Atom clone to test (I want it packaged in asar, snapshotted), by running `script/bootstrap`, copying the changes, and commenting out the bootstrap line in `script/build`. Maybe there is a better way to build Atom with a different private Git copy of a package, but it seems like `packageDependencies` doesn't support Git urls, and there is no obvious way to execute apm to install a Git package into a local Atom Git clone node_modules directory.

### Alternate Designs

Such issues likely repeat them self throughout the builtin Atom packages. Extracting such logic to a shared location and reusing it might help. Note that the exact logic required slightly different from case to case. Some resources are packaged in the asar archive, some are asar.unpacked, some are specially copied in the Atom build scripts. And each such case requires a different function.

### Benefits

Builtin snippets such as `snip` will work again.

### Possible Drawbacks

Yet another "calculate the right path" function.

### Applicable Issues

Fixes #243
