### PR TITLE
Correctly place tab stops when there are multiple indented lines

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -10,17 +10,12 @@ class SnippetExpansion
     @selections = [@cursor.selection]
 
     startPosition = @cursor.selection.getBufferRange().start
-    body = @snippet.body
-    indent = ""
-    tabStopRanges = []
-    if @snippet.lineCount > 1
-      lines = body.split('\n')
-      indent = @editor.lineTextForBufferRow(startPosition.row).match(/^\s*/)[0]
-      for line, index in lines when index isnt 0 # Do not include initial line
-        # Match initial line's indent
-        lines[index] = indent + line
-      body = lines.join('\n')
+    # Get leading indentation level
+    indent = @editor.lineTextForBufferRow(startPosition.row).match(/^\s*/)[0]
+    # Add proper indentation to the snippet
+    body = @snippet.body.replace(/\n/g, '\n' + indent)
 
+    tabStopRanges = []
     for tabStop in @snippet.tabStops
       ranges = []
       for range in tabStop

--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable, Range} = require 'atom'
 
 module.exports =
 class SnippetExpansion
@@ -17,18 +17,19 @@ class SnippetExpansion
       lines = body.split('\n')
       indent = @editor.lineTextForBufferRow(startPosition.row).match(/^\s*/)[0]
       for line, index in lines when index isnt 0 # Do not include initial line
-        # Match first line's indent
+        # Match initial line's indent
         lines[index] = indent + line
       body = lines.join('\n')
 
     for tabStop in @snippet.tabStops
       ranges = []
       for range in tabStop
-        unless startPosition.row is range.start.row
+        newRange = Range.fromObject(range, true) # Don't overwrite the existing range
+        if newRange.start.row # a non-zero start row means that we're not on the initial line
           # Add on the indent offset so that the tab stops are placed at the correct position
-          range.start.column += indent.length
-          range.end.column += indent.length
-        ranges.push(range)
+          newRange.start.column += indent.length
+          newRange.end.column += indent.length
+        ranges.push(newRange)
       tabStopRanges.push(ranges)
 
     @editor.transact =>

--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -10,11 +10,12 @@ class SnippetExpansion
     @selections = [@cursor.selection]
 
     startPosition = @cursor.selection.getBufferRange().start
+    {body, tabStops} = @snippet
     if @snippet.lineCount > 1 and indent = @editor.lineTextForBufferRow(startPosition.row).match(/^\s*/)[0]
       # Add proper leading indentation to the snippet
-      body = @snippet.body.replace(/\n/g, '\n' + indent)
+      body = body.replace(/\n/g, '\n' + indent)
 
-      tabStops = @snippet.tabStops.map (tabStop) ->
+      tabStops = tabStops.map (tabStop) ->
         tabStop.map (range) ->
           newRange = Range.fromObject(range, true) # Don't overwrite the existing range
           if newRange.start.row # a non-zero start row means that we're not on the initial line
@@ -22,8 +23,6 @@ class SnippetExpansion
             newRange.start.column += indent.length
             newRange.end.column += indent.length
           newRange
-    else
-      {body, tabStops} = @snippet
 
     @editor.transact =>
       newRange = @editor.transact =>

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -114,7 +114,7 @@ describe "Snippets extension", ->
             body: """
               line 1
               \tline 2$1
-
+              $2
             """
 
           "nested tab stops":
@@ -395,6 +395,19 @@ describe "Snippets extension", ->
             expect(editor.lineTextForBufferRow(2)).toBe "    if (items.length <= 1) return items; line 1"
             expect(editor.lineTextForBufferRow(3)).toBe "      line 2"
             expect(editor.getCursorBufferPosition()).toEqual [3, 12]
+
+          it "places tab stops correctly", ->
+            expect(editor.getSoftTabs()).toBeTruthy()
+            editor.setCursorScreenPosition([2, Infinity])
+            editor.insertText ' t3'
+            atom.commands.dispatch editorElement, 'snippets:expand'
+
+            markers = editor.getMarkers()
+            expect(markers.length).toBe 2
+            expect(markers[0].getBufferRange().start).toEqual row: 3, column: 12
+            expect(markers[0].getBufferRange().end).toEqual markers[0].getBufferRange().start
+            expect(markers[1].getBufferRange().start).toEqual row: 4, column: 4
+            expect(markers[1].getBufferRange().end).toEqual markers[1].getBufferRange().start
 
       describe "when multiple snippets match the prefix", ->
         it "expands the snippet that is the longest match for the prefix", ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -117,6 +117,13 @@ describe "Snippets extension", ->
               $2
             """
 
+          "multiline with indented placeholder tabstop":
+            prefix: "t4"
+            body: """
+              line ${1:1}
+                ${2:body...}
+            """
+
           "nested tab stops":
             prefix: "t5"
             body: '${1:"${2:key}"}: ${3:value}'
@@ -408,6 +415,41 @@ describe "Snippets extension", ->
             expect(markers[0].getBufferRange().end).toEqual markers[0].getBufferRange().start
             expect(markers[1].getBufferRange().start).toEqual row: 4, column: 4
             expect(markers[1].getBufferRange().end).toEqual markers[1].getBufferRange().start
+
+          it "does not change the relative positioning of the tab stops when inserted multiple times", ->
+            editor.setCursorScreenPosition([2, Infinity])
+            editor.insertNewline()
+            editor.insertText 't4'
+            atom.commands.dispatch editorElement, 'snippets:expand'
+
+            markers = editor.getMarkers()
+            expect(markers.length).toBe 2
+            expect(markers[0].getBufferRange().start).toEqual row: 3, column: 9
+            expect(markers[0].getBufferRange().end).toEqual row: 3, column: 10
+            expect(markers[1].getBufferRange().start).toEqual row: 4, column: 6
+            expect(markers[1].getBufferRange().end).toEqual row: 4, column: 13
+
+            atom.commands.dispatch editorElement, 'snippets:next-tab-stop'
+            editor.insertText 't4'
+            atom.commands.dispatch editorElement, 'snippets:expand'
+
+            markers = editor.getMarkers()
+            expect(markers.length).toBe 4
+            expect(markers[2].getBufferRange().start).toEqual row: 4, column: 11
+            expect(markers[2].getBufferRange().end).toEqual row: 4, column: 12
+            expect(markers[3].getBufferRange().start).toEqual row: 5, column: 8
+            expect(markers[3].getBufferRange().end).toEqual row: 5, column: 15
+
+            editor.setText('') # Clear editor
+            editor.insertText 't4'
+            atom.commands.dispatch editorElement, 'snippets:expand'
+
+            markers = editor.getMarkers()
+            expect(markers.length).toBe 6
+            expect(markers[4].getBufferRange().start).toEqual row: 0, column: 5
+            expect(markers[4].getBufferRange().end).toEqual row: 0, column: 6
+            expect(markers[5].getBufferRange().start).toEqual row: 1, column: 2
+            expect(markers[5].getBufferRange().end).toEqual row: 1, column: 9
 
       describe "when multiple snippets match the prefix", ->
         it "expands the snippet that is the longest match for the prefix", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Before this PR, this is how snippet expansion worked:
1. The entire snippet body would be inserted into the editor
2. Tab stop markers would be added
3. Tabs would be converted to spaces (and vice versa) if necessary
4. If the snippet consisted of multiple lines, all lines would be indented to match the first line's indentation level

This process worked pretty well, except for one case - when there was a tab stop at the beginning of a subsequent line in a multiline snippet.  In this case, the tab stop marker would initially be placed at `[line, 0], [line, 0]`.  However, when indenting that line in step 4, the marker is shifted and becomes `[line, 0], [line, indent]` since it touched the area where the shifting occurred (normally, if the editor changes and the marker does not include the changed region, both the start and end get shifted).  As a result, the leading whitespace would be selected instead of just placing the cursor at the tab stop.

With this PR, snippet expansion now works as follows:
1. The indentation level is retrieved and added to each subsequent line of the snippet body if multiline
2. Tab stop markers are shifted to correct for the added indentation
3. Snippet body with indentation is inserted into the editor
4. Tab stop markers corrected for indentation are added
5. Tabs would be converted to spaces (and vice versa) if necessary

### Alternate Designs

This could perhaps be done earlier in the file that calls SnippetExpansion.

### Benefits

I think this logic is more straightforward, since you don't have to think about how the markers will be internally shifted anymore.  It's all done explicitly.

### Possible Drawbacks

I don't see any.

### Applicable Issues

Fixes #140
Fixes #213