### PR TITLE
Error when duplicate keys are encountered

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -170,7 +170,7 @@ module.exports =
 
   loadSnippetsFile: (filePath, callback) ->
     return callback({}) unless CSON.isObjectPath(filePath)
-    CSON.readFile filePath, (error, object={}) ->
+    CSON.readFile filePath, {allowDuplicateKeys: false}, (error, object={}) ->
       if error?
         console.warn "Error reading snippets file '#{filePath}': #{error.stack ? error}"
         atom.notifications.addError("Failed to load snippets from '#{filePath}'", {detail: error.message, dismissable: true})


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR stops the loading of a snippets file if duplicate keys are encountered.  As duplicate keys are always a mistake, it makes sense to show an error.

### Alternate Designs

Only user snippets should be checked for duplicate keys.  Though if all snippets are checked, it's a good way to "shame" package authors into fixing their snippets file (such as core's language-sass).  The downside is more issues on atom/atom though as people copy/paste the error into a new issue.

### Benefits

Visible error with duplicate keys

### Possible Drawbacks

See alternate designs above.

### Applicable Issues

Fixes #72