### PR TITLE
Make `loaded` an instance variable

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -11,9 +11,8 @@ SnippetExpansion = require './snippet-expansion'
 {getPackageRoot} = require './helpers'
 
 module.exports =
-  loaded: false
-
   activate: ->
+    @loaded = false
     @userSnippetsPath = null
     @snippetIdCounter = 0
     @parsedSnippetsById = new Map

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -20,7 +20,7 @@ describe "Snippets extension", ->
       atom.packages.activatePackage('language-javascript')
 
     waitsForPromise ->
-      atom.packages.activatePackage("snippets")
+      atom.packages.activatePackage('snippets')
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
@@ -28,7 +28,7 @@ describe "Snippets extension", ->
 
   afterEach ->
     waitsForPromise ->
-      Promise.resolve(atom.packages.deactivatePackage("snippets"))
+      atom.packages.deactivatePackage('snippets')
 
   describe "provideSnippets interface", ->
     snippetsInterface = null
@@ -38,11 +38,24 @@ describe "Snippets extension", ->
 
     describe "bundledSnippetsLoaded", ->
       it "indicates the loaded state of the bundled snippets", ->
-        Snippets.loaded = false
         expect(snippetsInterface.bundledSnippetsLoaded()).toBe false
         Snippets.doneLoading()
         expect(snippetsInterface.bundledSnippetsLoaded()).toBe true
 
+      it "resets the loaded state after snippets is deactivated", ->
+        expect(snippetsInterface.bundledSnippetsLoaded()).toBe false
+        Snippets.doneLoading()
+        expect(snippetsInterface.bundledSnippetsLoaded()).toBe true
+
+        waitsForPromise -> atom.packages.deactivatePackage('snippets')
+        waitsForPromise -> atom.packages.activatePackage('snippets')
+
+        runs ->
+          expect(snippetsInterface.bundledSnippetsLoaded()).toBe false
+          Snippets.doneLoading()
+          expect(snippetsInterface.bundledSnippetsLoaded()).toBe true
+
+    describe "insertSnippet", ->
       it "can insert a snippet", ->
         editor.setSelectedBufferRange([[0, 4], [0, 13]])
         snippetsInterface.insertSnippet("hello ${1:world}", editor)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Before, `loaded` was a global variable.  This meant that once it was set to true it would stay true forever, even after deactivating and reactivating snippets.  This PR changes it to an instance variable so that its state is reset correctly across activations.

### Alternate Designs

None.

### Benefits

This makes the `bundledSnippetsLoaded` method of `provideSnippets()` much more reliable, as previously it would return the wrong value if snippets was deactivated then reactivated.

### Possible Drawbacks

None.

### Applicable Issues

Refs atom/settings-view#998, in which I have been experimenting with using `bundledSnippetsLoaded`.