### PR TITLE
When hitting tab within the last tab stop, jump to end of tab stop and terminate the snippet expansion

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -121,8 +121,9 @@ class SnippetExpansion
       else
         @goToNextTabStop()
     else
+      @goToEndOfLastTabStop()
       @destroy()
-      false
+      true
 
   goToPreviousTabStop: ->
     @setTabStopIndex(@tabStopIndex - 1) if @tabStopIndex > 0
@@ -162,6 +163,13 @@ class SnippetExpansion
     # made to the editor so that we can update the transformed tab stops.
     @snippets.observeEditor(@editor) if @hasTransforms
     markerSelected
+
+  goToEndOfLastTabStop: ->
+    return unless @tabStopMarkers.length > 0
+    markers = @tabStopMarkers[@tabStopMarkers.length - 1]
+    return unless markers.length > 0
+    lastMarker = markers[markers.length - 1]
+    @editor.setCursorBufferPosition(lastMarker.getEndBufferPosition())
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -178,10 +178,13 @@ class SnippetExpansion
 
   destroy: ->
     @subscriptions.dispose()
-    @snippets.getMarkerLayer(@editor).clear()
+    @getMarkerLayer(@editor).clear()
     @tabStopMarkers = []
     @snippets.stopObservingEditor(@editor)
     @snippets.clearExpansions(@editor)
+
+  getMarkerLayer: ->
+    @snippets.getMarkerLayer(@editor)
 
   restore: (@editor) ->
     @snippets.addExpansion(@editor, this)

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -17,6 +17,7 @@ module.exports =
     @userSnippetsPath = null
     @snippetIdCounter = 0
     @parsedSnippetsById = new Map
+    @editorMarkerLayers = new WeakMap
     @scopedPropertyStore = new ScopedPropertyStore
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.addOpener (uri) =>
@@ -53,6 +54,7 @@ module.exports =
         snippets.availableSnippetsView.toggle(editor)
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      @createMarkerLayer(editor)
       @clearExpansions(editor)
 
   deactivate: ->
@@ -332,6 +334,12 @@ module.exports =
 
   getStore: (editor) ->
     EditorStore.findOrCreate(editor)
+
+  createMarkerLayer: (editor) ->
+    @editorMarkerLayers.set(editor, editor.addMarkerLayer({maintainHistory: true}))
+
+  getMarkerLayer: (editor) ->
+    @editorMarkerLayers.get(editor)
 
   getExpansions: (editor) ->
     @getStore(editor).getExpansions()

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -334,7 +334,7 @@ describe "Snippets extension", ->
           simulateTabKeyEvent()
           simulateTabKeyEvent()
           simulateTabKeyEvent()
-          expect(editor.lineTextForBufferRow(2)).toBe "go here next:(abc) and finally go here:(  )"
+          expect(editor.lineTextForBufferRow(2)).toBe "go here next:(abc) and finally go here:()"
           expect(editor.getMarkerCount()).toBe markerCountBefore
 
         describe "when tab stops are nested", ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -463,13 +463,9 @@ describe "Snippets extension", ->
           editor.setCursorScreenPosition([2, Infinity])
           editor.insertText ' t3'
           atom.commands.dispatch editorElement, 'snippets:expand'
-
-          markers = editor.getMarkers()
-          expect(markers.length).toBe 2
-          expect(markers[0].getBufferRange().start).toEqual row: 3, column: 12
-          expect(markers[0].getBufferRange().end).toEqual markers[0].getBufferRange().start
-          expect(markers[1].getBufferRange().start).toEqual row: 4, column: 4
-          expect(markers[1].getBufferRange().end).toEqual markers[1].getBufferRange().start
+          expect(editor.getCursorBufferPosition()).toEqual [3, 12]
+          atom.commands.dispatch editorElement, 'snippets:next-tab-stop'
+          expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
         it "indents the subsequent lines of the snippet based on the indent level before the snippet is inserted", ->
           editor.setCursorScreenPosition([2, Infinity])
@@ -488,34 +484,24 @@ describe "Snippets extension", ->
           editor.insertText 't4'
           atom.commands.dispatch editorElement, 'snippets:expand'
 
-          markers = editor.getMarkers()
-          expect(markers.length).toBe 2
-          expect(markers[0].getBufferRange().start).toEqual row: 3, column: 9
-          expect(markers[0].getBufferRange().end).toEqual row: 3, column: 10
-          expect(markers[1].getBufferRange().start).toEqual row: 4, column: 6
-          expect(markers[1].getBufferRange().end).toEqual row: 4, column: 13
-
+          expect(editor.getSelectedBufferRange()).toEqual [[3, 9], [3, 10]]
           atom.commands.dispatch editorElement, 'snippets:next-tab-stop'
+          expect(editor.getSelectedBufferRange()).toEqual [[4, 6], [4, 13]]
+
           editor.insertText 't4'
           atom.commands.dispatch editorElement, 'snippets:expand'
 
-          markers = editor.getMarkers()
-          expect(markers.length).toBe 4
-          expect(markers[2].getBufferRange().start).toEqual row: 4, column: 11
-          expect(markers[2].getBufferRange().end).toEqual row: 4, column: 12
-          expect(markers[3].getBufferRange().start).toEqual row: 5, column: 8
-          expect(markers[3].getBufferRange().end).toEqual row: 5, column: 15
+          expect(editor.getSelectedBufferRange()).toEqual [[4, 11], [4, 12]]
+          atom.commands.dispatch editorElement, 'snippets:next-tab-stop'
+          expect(editor.getSelectedBufferRange()).toEqual [[5, 8], [5, 15]]
 
           editor.setText('') # Clear editor
           editor.insertText 't4'
           atom.commands.dispatch editorElement, 'snippets:expand'
 
-          markers = editor.getMarkers()
-          expect(markers.length).toBe 6
-          expect(markers[4].getBufferRange().start).toEqual row: 0, column: 5
-          expect(markers[4].getBufferRange().end).toEqual row: 0, column: 6
-          expect(markers[5].getBufferRange().start).toEqual row: 1, column: 2
-          expect(markers[5].getBufferRange().end).toEqual row: 1, column: 9
+          expect(editor.getSelectedBufferRange()).toEqual [[0, 5], [0, 6]]
+          atom.commands.dispatch editorElement, 'snippets:next-tab-stop'
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 2], [1, 9]]
 
       describe "when multiple snippets match the prefix", ->
         it "expands the snippet that is the longest match for the prefix", ->


### PR DESCRIPTION
### Description of the Change

Previously, when you hit `tab` inside the last tab stop of a snippet, it would be treated as an ordinary `tab`.

Now, to bring Atom's behavior more in line with Sublime Text, hitting tab within the last tab stop moves the cursor to the end of the tab stop and terminates the snippet expansion. From this point forward, the tab stops will no longer be present and `tab` will function as it normally does.

![snippets-last-tab-stop](https://user-images.githubusercontent.com/1789/34635995-3810bcba-f255-11e7-9bce-7dc1cff0d1d5.gif)

This PR also moves tab stop markers into their own marker layer so that they can be managed with the history. I had hoped this would enable you to cycle through tab stops after expanding, undoing, and redoing, but there is a bug in restoring markers that will need to be fixed before that will work.

### Benefits

This prevents us from leaking markers and provides a somewhat more intuitive experience for eliminating tab stops.

### Alternate Designs

Ultimately, I think we need to rethink our approach to tab stops entirely. It would be better to enter a snippet editing mode that highlighted the tab stops in a different color and that you exit either by hitting escape or by tabbing off the end. That's a bigger project though.

### Possible Drawbacks

It may be surprising that tab doesn't indent code when editing the last tab stop until the tab stop is completely dismissed.

### Applicable Issues

Fixes #248
 
/cc @50Wliu 