### PR TITLE
Fallback to reading snippets with legacy scope aliases if available

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -217,6 +217,10 @@ module.exports =
 
   parsedSnippetsForScopes: (scopeDescriptor) ->
     unparsedSnippetsByPrefix = @scopedPropertyStore.getPropertyValue(@getScopeChain(scopeDescriptor), "snippets")
+    unless unparsedSnippetsByPrefix?
+      legacyScopeDescriptor = atom.config.getLegacyScopeDescriptorForNewScopeDescriptor?(scopeDescriptor)
+      if legacyScopeDescriptor?
+        unparsedSnippetsByPrefix = @scopedPropertyStore.getPropertyValue(@getScopeChain(legacyScopeDescriptor), "snippets")
     unparsedSnippetsByPrefix ?= {}
     snippets = {}
     for prefix, attributes of unparsedSnippetsByPrefix

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -102,6 +102,19 @@ describe "Snippets extension", ->
       expect(snippets.snippetsForScopes(['.source.js'])['t1']).toBeTruthy()
       expect(snippets.snippetsForScopes(['.source.js .nope.not-today'])['t1']).toBeFalsy()
 
+  if atom.config.setLegacyScopeAliasForNewScope?
+    it "reads snippets using the scope name's legacy alias if available", ->
+      Snippets.add __filename,
+        '.source.js':
+          "some snippet":
+            prefix: "t1"
+            body: "this is a test"
+
+      atom.config.setLegacyScopeAliasForNewScope('javascript', 'source.js')
+
+      snippets = Snippets.provideSnippets()
+      expect(snippets.snippetsForScopes(['javascript'])['t1'].name).toEqual('some snippet')
+
   describe "when 'tab' is triggered on the editor", ->
     beforeEach ->
       Snippets.add __filename,


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/16621
Depends on https://github.com/atom/atom/pull/16797