### PR TITLE
Fix incorrect parsing of placeholders that point to other tab stops.

### DIFF
--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -1,3 +1,27 @@
+{
+  // Joins all consecutive strings in a collection without clobbering any
+  // non-string members.
+  function coalesce (parts) {
+  	var result = [], ri;
+    var part;
+    for (var i = 0; i < parts.length; i++) {
+      part = parts[i];
+      ri = result.length - 1;
+      if (typeof part === 'string' && typeof result[ri] === 'string') {
+     	  result[ri] = result[ri] + part;
+      } else {
+        result.push(part);
+      }
+    }
+    return result;
+  }
+
+  function flatten (parts) {
+    return parts.reduce(function (flat, rest) {
+      return flat.concat(Array.isArray(rest) ? flatten(rest) : rest);
+    }, []);
+  }
+}
 bodyContent = content:(tabStop / bodyContentText)* { return content; }
 bodyContentText = text:bodyContentChar+ { return text.join(''); }
 bodyContentChar = escaped / !tabStop char:. { return char; }
@@ -21,11 +45,14 @@ tabStopWithTransformation = '${' index:[0-9]+ substitution:transformationSubstit
     substitution: substitution
   };
 }
-placeholderContent = content:(placeholderContentText / tabStop / variable )* { return content; }
-placeholderContentText = text:placeholderContentChar+ { return text.join(''); }
+
+placeholderContent = content:(tabStop / placeholderContentText / variable )* { return flatten(content); }
+placeholderContentText = text:placeholderContentChar+ { return coalesce(text); }
 placeholderContentChar = escaped / placeholderVariableReference / !tabStop !variable char:[^}] { return char; }
 
-placeholderVariableReference = '$' digit:[0-9]+ { return { index: parseInt(digit.join(""), 10) }; }
+placeholderVariableReference = '$' digit:[0-9]+ {
+  return { index: parseInt(digit.join(""), 10), content: [] };
+}
 
 variable = '${' variableContent '}' {
   return ''; // we eat variables and do nothing with them for now

--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -2,11 +2,10 @@
   // Joins all consecutive strings in a collection without clobbering any
   // non-string members.
   function coalesce (parts) {
-    var result = [], ri;
-    var part;
-    for (var i = 0; i < parts.length; i++) {
-      part = parts[i];
-      ri = result.length - 1;
+    const result = [];
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const ri = result.length - 1;
       if (typeof part === 'string' && typeof result[ri] === 'string') {
         result[ri] = result[ri] + part;
       } else {

--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -2,13 +2,13 @@
   // Joins all consecutive strings in a collection without clobbering any
   // non-string members.
   function coalesce (parts) {
-  	var result = [], ri;
+    var result = [], ri;
     var part;
     for (var i = 0; i < parts.length; i++) {
       part = parts[i];
       ri = result.length - 1;
       if (typeof part === 'string' && typeof result[ri] === 'string') {
-     	  result[ri] = result[ri] + part;
+        result[ri] = result[ri] + part;
       } else {
         result.push(part);
       }

--- a/spec/body-parser-spec.coffee
+++ b/spec/body-parser-spec.coffee
@@ -198,3 +198,46 @@ describe "Snippet Body Parser", ->
       },
       '>'
     ]
+
+  it "parses a snippet with a placeholder that mirrors another tab stop's content", ->
+    bodyTree = BodyParser.parse """
+    $4console.${3:log}('${2:$1}', $1);$0
+    """
+
+    expect(bodyTree).toEqual [
+      {index: 4, content: [] },
+      'console.',
+      {index: 3, content: ['log'] },
+      '(\'',
+      {
+        index: 2, content: [
+          { index: 1, content: [] }
+        ]
+      },
+      '\', ',
+      {index: 1, content: []},
+      ');',
+      {index: 0, content: []}
+    ]
+
+  it "parses a snippet with a placeholder that mixes text and tab stop references", ->
+    bodyTree = BodyParser.parse """
+    $4console.${3:log}('${2:uh $1}', $1);$0
+    """
+
+    expect(bodyTree).toEqual [
+      {index: 4, content: [] },
+      'console.',
+      {index: 3, content: ['log'] },
+      '(\'',
+      {
+        index: 2, content: [
+          'uh ',
+          { index: 1, content: [] }
+        ]
+      },
+      '\', ',
+      {index: 1, content: []},
+      ');',
+      {index: 0, content: []}
+    ]

--- a/spec/body-parser-spec.coffee
+++ b/spec/body-parser-spec.coffee
@@ -205,13 +205,13 @@ describe "Snippet Body Parser", ->
     """
 
     expect(bodyTree).toEqual [
-      {index: 4, content: [] },
+      {index: 4, content: []},
       'console.',
-      {index: 3, content: ['log'] },
+      {index: 3, content: ['log']},
       '(\'',
       {
         index: 2, content: [
-          { index: 1, content: [] }
+          {index: 1, content: []}
         ]
       },
       '\', ',
@@ -226,14 +226,14 @@ describe "Snippet Body Parser", ->
     """
 
     expect(bodyTree).toEqual [
-      {index: 4, content: [] },
+      {index: 4, content: []},
       'console.',
-      {index: 3, content: ['log'] },
+      {index: 3, content: ['log']},
       '(\'',
       {
         index: 2, content: [
           'uh ',
-          { index: 1, content: [] }
+          {index: 1, content: []}
         ]
       },
       '\', ',

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -248,6 +248,9 @@ describe "Snippets extension", ->
             body: """
             & ${1/(.)/\\u$1/} & ${1:q}
             """
+          "has a placeholder that mirrors another tab stop's content":
+            prefix: 't17'
+            body: "$4console.${3:log}('${2:uh $1}', $1);$0"
 
     it "parses snippets once, reusing cached ones on subsequent queries", ->
       spyOn(Snippets, "getBodyParser").andCallThrough()
@@ -665,6 +668,16 @@ describe "Snippets extension", ->
         editor.insertText('line 3')
 
         expect(editor.lineTextForBufferRow(2).indexOf("line 2 ")).toBe -1
+
+      it "mirrors input properly when a tabstop's placeholder refers to another tabstop", ->
+        editor.setText('t17')
+        editor.setCursorScreenPosition([0, 3])
+        simulateTabKeyEvent()
+        editor.insertText("foo")
+        expect(editor.getText()).toBe "console.log('uh foo', foo);"
+        simulateTabKeyEvent()
+        editor.insertText("bar")
+        expect(editor.getText()).toBe "console.log('bar', foo);"
 
     describe "when the snippet contains tab stops with transformations", ->
       it "transforms the text typed into the first tab stop before setting it in the transformed tab stop", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

#266 describes a regression with tab stop behavior when the placeholder contains a reference to another tab stop. This almost certainly happened as a result of #260, but there wasn't any test coverage for this particular usage.

### Alternate Designs

The parser was incorrectly assuming that all the items it would receive for a particular rule would be represented as strings, and that it could thus join them all together. Tabstop references are represented as objects. So I wrote a couple of utility functions to ensure that adjacent strings would be merged together without incorrectly coercing objects.

If there's an easier way to do this with a PEG, I'm all for it. Parser grammars are not my strong suit.


### Applicable Issues

#266 