### PR TITLE
Make snippets work for editors that aren't pane items

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -101,7 +101,10 @@ class SnippetExpansion
       for insertion in insertions
         {range} = insertion
         {start, end} = range
-        marker = @snippets.getMarkerLayer(@editor).markBufferRange([startPosition.traverse(start), startPosition.traverse(end)])
+        marker = @getMarkerLayer(@editor).markBufferRange([
+          startPosition.traverse(start),
+          startPosition.traverse(end)
+        ])
         markers.push({
           index: markers.length,
           marker: marker,
@@ -184,7 +187,7 @@ class SnippetExpansion
     @snippets.clearExpansions(@editor)
 
   getMarkerLayer: ->
-    @snippets.getMarkerLayer(@editor)
+    @snippets.findOrCreateMarkerLayer(@editor)
 
   restore: (@editor) ->
     @snippets.addExpansion(@editor, this)

--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -53,10 +53,6 @@ module.exports =
         snippets.availableSnippetsView ?= new SnippetsAvailable(snippets)
         snippets.availableSnippetsView.toggle(editor)
 
-    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
-      @createMarkerLayer(editor)
-      @clearExpansions(editor)
-
   deactivate: ->
     @emitter?.dispose()
     @emitter = null
@@ -312,6 +308,7 @@ module.exports =
         @onUndoOrRedo(editor, event, false)
     })
 
+    @findOrCreateMarkerLayer(editor)
     editor.transact =>
       cursors = editor.getCursors()
       for cursor in cursors
@@ -342,8 +339,12 @@ module.exports =
   createMarkerLayer: (editor) ->
     @editorMarkerLayers.set(editor, editor.addMarkerLayer({maintainHistory: true}))
 
-  getMarkerLayer: (editor) ->
-    @editorMarkerLayers.get(editor)
+  findOrCreateMarkerLayer: (editor) ->
+    layer = @editorMarkerLayers.get(editor)
+    unless layer?
+      layer = editor.addMarkerLayer({maintainHistory: true})
+      @editorMarkerLayers.set(editor, layer)
+    layer
 
   getExpansions: (editor) ->
     @getStore(editor).getExpansions()

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 temp = require('temp').track()
 Snippets = require '../lib/snippets'
+{TextEditor} = require 'atom'
 
 describe "Snippets extension", ->
   [editorElement, editor] = []
@@ -921,6 +922,24 @@ describe "Snippets extension", ->
           expect(editor.lineTextForBufferRow(0)).toBe "one t1 threevar quicksort = function () {"
           expect(editor.lineTextForBufferRow(7)).toBe "    }one t1 three"
           expect(editor.lineTextForBufferRow(12)).toBe "};one t1 three"
+
+    describe "when the editor is not a pane item (regression)", ->
+      it "handles tab stops correctly", ->
+        editor = new TextEditor()
+        atom.grammars.assignLanguageMode(editor, 'source.js')
+        editorElement = editor.getElement()
+
+        editor.insertText('t2')
+        simulateTabKeyEvent()
+        editor.insertText('ABC')
+        expect(editor.getText()).toContain('go here first:(ABC)')
+
+        editor.undo()
+        editor.undo()
+        expect(editor.getText()).toBe('t2')
+        simulateTabKeyEvent()
+        editor.insertText('ABC')
+        expect(editor.getText()).toContain('go here first:(ABC)')
 
   describe "when atom://.atom/snippets is opened", ->
     it "opens ~/.atom/snippets.cson", ->


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/17055

This package adds commands to *all* text-editors, but previously, some of its internal state was only maintained for text editors that were added to the workspace as pane items. This PR makes the package work for all text editors, including the commit message editor.