### PR TITLE
Add the ability to disable a package’s snippets.

### DIFF
--- a/lib/snippets.coffee
+++ b/lib/snippets.coffee
@@ -16,9 +16,19 @@ module.exports =
     @loaded = false
     @userSnippetsPath = null
     @snippetIdCounter = 0
+    @snippetsByPackage = new Map
     @parsedSnippetsById = new Map
     @editorMarkerLayers = new WeakMap
+
     @scopedPropertyStore = new ScopedPropertyStore
+    # The above ScopedPropertyStore will store the main registry of snippets.
+    # But we need a separate ScopedPropertyStore for the snippets that come
+    # from disabled packages. They're isolated so that they're not considered
+    # as candidates when the user expands a prefix, but we still need the data
+    # around so that the snippets provided by those packages can be shown in
+    # the settings view.
+    @disabledSnippetsScopedPropertyStore = new ScopedPropertyStore
+
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.addOpener (uri) =>
       if uri is 'atom://.atom/snippets'
@@ -27,6 +37,9 @@ module.exports =
     @loadAll()
     @watchUserSnippets (watchDisposable) =>
       @subscriptions.add(watchDisposable)
+
+    @subscriptions.add atom.config.onDidChange 'core.packagesWithSnippetsDisabled', ({ newValue, oldValue }) =>
+      @handleDisabledPackagesDidChange(newValue, oldValue)
 
     snippets = this
 
@@ -120,6 +133,8 @@ module.exports =
       else
         callback(new Disposable -> )
 
+  # Called when a user's snippets file is changed, deleted, or moved so that we
+  # can immediately re-process the snippets it contains.
   handleUserSnippetsDidChange: ->
     userSnippetsPath = @getUserSnippetsPath()
     atom.config.transact =>
@@ -127,12 +142,61 @@ module.exports =
       @loadSnippetsFile userSnippetsPath, (result) =>
         @add(userSnippetsPath, result)
 
+  # Called when the "Enable" checkbox is checked/unchecked in the Snippets
+  # section of a package's settings view.
+  handleDisabledPackagesDidChange: (newDisabledPackages, oldDisabledPackages) ->
+    packagesToAdd = []
+    packagesToRemove = []
+    oldDisabledPackages ?= []
+    newDisabledPackages ?= []
+    for p in oldDisabledPackages
+      packagesToAdd.push(p) unless newDisabledPackages.includes(p)
+
+    for p in newDisabledPackages
+      packagesToRemove.push(p) unless oldDisabledPackages.includes(p)
+
+    atom.config.transact =>
+      @removeSnippetsForPackage(p) for p in packagesToRemove
+      @addSnippetsForPackage(p) for p in packagesToAdd
+
+  addSnippetsForPackage: (packageName) ->
+    snippetSet = @snippetsByPackage.get(packageName)
+    for filePath, snippetsBySelector of snippetSet
+      @add(filePath, snippetsBySelector)
+
+  removeSnippetsForPackage: (packageName) ->
+    snippetSet = @snippetsByPackage.get(packageName)
+    for filePath, snippetsBySelector of snippetSet
+      @clearSnippetsForPath(filePath)
+
   loadPackageSnippets: (callback) ->
-    packages = atom.packages.getLoadedPackages()
-    snippetsDirPaths = (path.join(pack.path, 'snippets') for pack in packages).sort (a, b) ->
-      if /\/app\.asar\/node_modules\//.test(a) then -1 else 1
-    async.map snippetsDirPaths, @loadSnippetsDirectory.bind(this), (error, results) ->
-      callback(_.extend({}, results...))
+    disabledPackageNames = atom.config.get('core.packagesWithSnippetsDisabled') || []
+    packages = atom.packages.getLoadedPackages().sort (pack, b) ->
+      if /\/app\.asar\/node_modules\//.test(pack.path) then -1 else 1
+
+    snippetsDirPaths = (path.join(pack.path, 'snippets') for pack in packages)
+
+    async.map snippetsDirPaths, @loadSnippetsDirectory.bind(this), (error, results) =>
+      zipped = ({result: result, pack: packages[key]} for key, result of results)
+      enabledPackages = []
+      for o in zipped
+        # Skip packages that contain no snippets.
+        continue if Object.keys(o.result).length is 0
+        # Keep track of which snippets come from which packages so we can
+        # unload them selectively later. All packages get put into this map,
+        # even disabled packages, because we need to know which snippets to add
+        # if those packages are enabled again.
+        @snippetsByPackage.set(o.pack.name, o.result)
+        if disabledPackageNames.includes(o.pack.name)
+          # Since disabled packages' snippets won't get added to the main
+          # ScopedPropertyStore, we'll keep track of them in a separate
+          # ScopedPropertyStore so that they can still be represented in the
+          # settings view.
+          @addSnippetsInDisabledPackage(o.result)
+        else
+          enabledPackages.push(o.result)
+
+      callback(_.extend({}, enabledPackages...))
 
   doneLoading: ->
     @loaded = true
@@ -174,7 +238,7 @@ module.exports =
         atom.notifications.addError("Failed to load snippets from '#{filePath}'", {detail: error.message, dismissable: true})
       callback(object)
 
-  add: (filePath, snippetsBySelector) ->
+  add: (filePath, snippetsBySelector, isDisabled = false) ->
     for selector, snippetsByName of snippetsBySelector
       unparsedSnippetsByPrefix = {}
       for name, attributes of snippetsByName
@@ -186,8 +250,12 @@ module.exports =
         else if not body?
           unparsedSnippetsByPrefix[prefix] = null
 
-      @storeUnparsedSnippets(unparsedSnippetsByPrefix, filePath, selector)
+      @storeUnparsedSnippets(unparsedSnippetsByPrefix, filePath, selector, isDisabled)
     return
+
+  addSnippetsInDisabledPackage: (bundle) ->
+    for filePath, snippetsBySelector of bundle
+      @add(filePath, snippetsBySelector, true)
 
   getScopeChain: (object) ->
     scopesArray = object?.getScopesArray?()
@@ -198,10 +266,16 @@ module.exports =
         scope
       .join(' ')
 
-  storeUnparsedSnippets: (value, path, selector) ->
+  storeUnparsedSnippets: (value, path, selector, isDisabled = false) ->
+    # The `isDisabled` flag determines which scoped property store we'll use.
+    # Active snippets get put into one and inactive snippets get put into
+    # another. Only the first one gets consulted when we look up a snippet
+    # prefix for expansion, but both stores have their contents exported when
+    # the settings view asks for all available snippets.
     unparsedSnippets = {}
     unparsedSnippets[selector] = {"snippets": value}
-    @scopedPropertyStore.addProperties(path, unparsedSnippets, priority: @priorityForSource(path))
+    store = if isDisabled then @disabledSnippetsScopedPropertyStore else @scopedPropertyStore
+    store.addProperties(path, unparsedSnippets, priority: @priorityForSource(path))
 
   clearSnippetsForPath: (path) ->
     for scopeSelector of @scopedPropertyStore.propertiesForSource(path)
@@ -415,7 +489,21 @@ module.exports =
     new SnippetExpansion(snippet, editor, cursor, this)
 
   getUnparsedSnippets: ->
-    _.deepClone(@scopedPropertyStore.propertySets)
+    results = []
+    iterate = (sets) ->
+      for item in sets
+        newItem = _.deepClone(item)
+        # The atom-slick library has already parsed the `selector` property, so
+        # it's an AST here instead of a string. The object has a `toString`
+        # method that turns it back into a string. That custom behavior won't
+        # be preserved in the deep clone of the object, so we have to handle it
+        # separately.
+        newItem.selectorString = item.selector.toString()
+        results.push(newItem)
+
+    iterate(@scopedPropertyStore.propertySets)
+    iterate(@disabledSnippetsScopedPropertyStore.propertySets)
+    results
 
   provideSnippets: ->
     bundledSnippetsLoaded: => @loaded

--- a/spec/fixtures/package-with-snippets/snippets/test.cson
+++ b/spec/fixtures/package-with-snippets/snippets/test.cson
@@ -17,6 +17,11 @@
     leftLabelHTML: "<span style=\"color:red\">Label</span>"
     rightLabelHTML: "<span style=\"color:white\">Label</span>"
 
+".package-with-snippets-unique-scope":
+  "Test Snippet":
+    prefix: "test"
+    body: "testing 123"  
+
 ".source.js":
   "Overrides a core package's snippet":
     prefix: "log"

--- a/spec/snippet-loading-spec.coffee
+++ b/spec/snippet-loading-spec.coffee
@@ -211,3 +211,45 @@ describe "Snippet Loading", ->
     runs ->
       expect(console.warn).toHaveBeenCalled()
       expect(atom.notifications.addError).toHaveBeenCalled() if atom.notifications?
+
+  describe "packages-with-snippets-disabled feature", ->
+    it "disables no snippets if the config option is empty", ->
+      originalConfig = atom.config.get('core.packagesWithSnippetsDisabled')
+      atom.config.set('core.packagesWithSnippetsDisabled', [])
+
+      activateSnippetsPackage()
+      runs ->
+        snippets = snippetsService.snippetsForScopes(['.package-with-snippets-unique-scope'])
+        expect(Object.keys(snippets).length).toBe 1
+        atom.config.set('core.packagesWithSnippetsDisabled', originalConfig)
+
+    it "never loads a package's snippets when that package is disabled in config", ->
+      originalConfig = atom.config.get('core.packagesWithSnippetsDisabled')
+      atom.config.set('core.packagesWithSnippetsDisabled', ['package-with-snippets'])
+
+      activateSnippetsPackage()
+      runs ->
+        snippets = snippetsService.snippetsForScopes(['.package-with-snippets-unique-scope'])
+        expect(Object.keys(snippets).length).toBe 0
+        atom.config.set('core.packagesWithSnippetsDisabled', originalConfig)
+
+    it "unloads and/or reloads snippets from a package if the config option is changed after activation", ->
+      originalConfig = atom.config.get('core.packagesWithSnippetsDisabled')
+      atom.config.set('core.packagesWithSnippetsDisabled', [])
+
+      activateSnippetsPackage()
+      runs ->
+        snippets = snippetsService.snippetsForScopes(['.package-with-snippets-unique-scope'])
+        expect(Object.keys(snippets).length).toBe 1
+
+        # Disable it.
+        atom.config.set('core.packagesWithSnippetsDisabled', ['package-with-snippets'])
+        snippets = snippetsService.snippetsForScopes(['.package-with-snippets-unique-scope'])
+        expect(Object.keys(snippets).length).toBe 0
+
+        # Re-enable it.
+        atom.config.set('core.packagesWithSnippetsDisabled', [])
+        snippets = snippetsService.snippetsForScopes(['.package-with-snippets-unique-scope'])
+        expect(Object.keys(snippets).length).toBe 1
+
+        atom.config.set('core.packagesWithSnippetsDisabled', originalConfig)


### PR DESCRIPTION
### Description of the Change

I wanted to pick up where #242 left off; @layonferreira did some great work, but had to put the PR aside for lack of time.

I cribbed from that PR a bit and also looked at the existing code for keymaps. The exact UI is being worked out in atom/settings-view#1076, but if everyone’s agreed that this functionality should essentially behave like per-package keymap disabling, then the logic we need within the snippets package is pretty straightforward.

There’s a new `Map` in there so we can associate a package's name with the snippet file(s) and snippets that it loads, and a new `ScopedPropertyStore` to act as a sort of quarantine zone for any snippets that get disabled. That store will get ignored by most methods but is consulted in the `getUnparsedSnippets` method so that the settings view is made aware of _all_ snippets, not just the ones that happen to be active right now. Imagine seeing a list of ten snippets in a package’s Settings view, unchecking the “Enable” box above that list, and seeing those ten snippets disappear… because you just deactivated them. The second `ScopedPropertyStore` is how we avoid that pitfall.

We spy on the `core.packagesWithDisabledSnippets` setting so that we can do targeted adding or removing of certain snippets when the setting changes. It will not be necessary to reload the window. The change handler will add or remove the smallest number of snippets possible to account for the settings change; bundled snippets and user-defined snippets won’t get touched, nor will snippets from unrelated packages.

### Alternate Designs

The proposed design was selected almost entirely upon the feedback given in #242. If, within this design, there are better ways to accomplish any of the things that this PR adds, please let me know.

### Benefits

Issue #55 has been open since 2014. It’s a quality-of-life issue when you accidentally trigger a snippet you didn’t realize existed, or have snippets suggested to you that aren’t helpful and that you’ll never use. It might also make package authors feel more entitled to include snippets in their packages without worrying if it’s too opinionated of a choice to push out to their users.

### Possible Drawbacks

Aside from bugs, I can’t really think of any. This change shouldn’t regress performance for anyone who doesn’t care about this feature. (And it could theoretically improve the startup time of this package in an extreme case where a user has disabled most or all of the snippets provided by packages. But I haven’t tested this.)

### Applicable Issues

Original issue is #55; PR #242 was a previous attempt to close it.
