### PR TITLE
Fix behavior when pressing Tab after a snippet reaches an explicit end stop.

### DIFF
--- a/lib/snippet-expansion.coffee
+++ b/lib/snippet-expansion.coffee
@@ -126,9 +126,15 @@ class SnippetExpansion
       else
         @goToNextTabStop()
     else
-      succeeded = @goToEndOfLastTabStop()
-      @destroy()
-      succeeded
+      # The user has tabbed past the last tab stop. If the last tab stop is a
+      # $0, we shouldn't move the cursor any further.
+      if @snippet.tabStopList.hasEndStop
+        @destroy()
+        false
+      else
+        succeeded = @goToEndOfLastTabStop()
+        @destroy()
+        succeeded
 
   goToPreviousTabStop: ->
     @setTabStopIndex(@tabStopIndex - 1) if @tabStopIndex > 0
@@ -168,6 +174,7 @@ class SnippetExpansion
     # If this snippet has at least one transform, we need to observe changes
     # made to the editor so that we can update the transformed tab stops.
     @snippets.observeEditor(@editor) if @hasTransforms
+
     markerSelected
 
   goToEndOfLastTabStop: ->

--- a/lib/tab-stop-list.js
+++ b/lib/tab-stop-list.js
@@ -10,6 +10,10 @@ class TabStopList {
     return Object.keys(this.list).length
   }
 
+  get hasEndStop () {
+    return !!this.list[Infinity]
+  }
+
   findOrCreate ({ index, snippet }) {
     if (!this.list[index]) {
       this.list[index] = new TabStop({ index, snippet })

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -111,6 +111,10 @@ describe "Snippets extension", ->
             prefix: "t1"
             body: "this is a test"
 
+          "with only an end tab stop":
+            prefix: "t1a"
+            body: "something $0 strange"
+
           "overlapping prefix":
             prefix: "tt1"
             body: "this is another test"
@@ -341,7 +345,7 @@ describe "Snippets extension", ->
           simulateTabKeyEvent()
           simulateTabKeyEvent()
           simulateTabKeyEvent()
-          expect(editor.lineTextForBufferRow(2)).toBe "go here next:(abc) and finally go here:()"
+          expect(editor.lineTextForBufferRow(2)).toBe "go here next:(abc) and finally go here:(  )"
           expect(editor.getMarkerCount()).toBe markerCountBefore
 
         describe "when tab stops are nested", ->
@@ -354,6 +358,19 @@ describe "Snippets extension", ->
             editor.insertText("foo")
             simulateTabKeyEvent()
             expect(editor.getSelectedBufferRange()).toEqual [[0, 5], [0, 10]]
+
+        describe "when the only tab stop is an end stop", ->
+          it "terminates the snippet immediately after moving the cursor to the end stop", ->
+            editor.setText('')
+            editor.insertText 't1a'
+            simulateTabKeyEvent()
+
+            expect(editor.lineTextForBufferRow(0)).toBe "something  strange"
+            expect(editor.getCursorBufferPosition()).toEqual [0, 10]
+
+            simulateTabKeyEvent()
+            expect(editor.lineTextForBufferRow(0)).toBe "something    strange"
+            expect(editor.getCursorBufferPosition()).toEqual [0, 12]
 
         describe "when tab stops are separated by blank lines", ->
           it "correctly places the tab stops (regression)", ->


### PR DESCRIPTION
Fixes #278.

### Description of the Change

Issue #278 describes the problem: when a snippet contains an explicit `$0`, and when the user cycles through the snippet to that end stop, the next press of <kbd>Tab</kbd> does nothing. This doesn’t have any benefit for the user and behaves differently from other implementations of snippets (Sublime Text, VSCode, etc.).

### Alternate Designs

This behavior was introduced (inadvertently, I think) in #262, whose effect was to add an implied `$0` at the end of every snippet that didn’t have its own `$0`. If I were doing a larger overhaul here, I’d want to refactor so as to remove the need for a `goToEndOfLastTabStop` method altogether. But I think that’d be touching a lot of code just to fix a pretty minor issue, so I went for the simpler fix.

### Benefits

Brings the behavior of snippets more in line with other IDEs’ implementations. Annoys the user less.

### Possible Drawbacks

The behavior change will perhaps be surprising to people the first time it happens. But nobody will mind unless they had grown particularly fond of pressing <kbd>Tab</kbd> and having it do nothing.

### Applicable Issues

Reported in #278. #262 is the source of the unwanted behavior.
