### PR TITLE
Add regression tests for tab stops at ends of snippets

### DIFF
--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -165,6 +165,14 @@ describe "Snippets extension", ->
                 ${2:placeholder ending second line}
             """
 
+          "tab stops at the ends of snippets":
+            prefix: "t6b"
+            body: "$1expanded$0"
+
+          "tab stops at the ends of snippets - alternative":
+            prefix: "t6c"
+            body: "$0expanded$1"
+
           "contains empty lines":
             prefix: "t7"
             body: """
@@ -590,6 +598,28 @@ describe "Snippets extension", ->
         expect(editor.lineTextForBufferRow(0)).toBe "t6"
         simulateTabKeyEvent()
         expect(editor.lineTextForBufferRow(0)).toBe "first line"
+
+      it "does not remember the tab stops when the whole snippet has been undone (regression)", ->
+        editor.insertText 't6b\n'
+        editor.setCursorBufferPosition [0, 3]
+        simulateTabKeyEvent()
+        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+        editor.undo()
+        expect(editor.lineTextForBufferRow(0)).toBe "t6b"
+        simulateTabKeyEvent()
+        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 0])
+
+      it "does not remember the tab stops when the whole snippet has been undone (regression, alternative version)", ->
+        editor.insertText 't6c\n'
+        editor.setCursorBufferPosition [0, 3]
+        simulateTabKeyEvent()
+        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+        editor.undo()
+        expect(editor.lineTextForBufferRow(0)).toBe "t6c"
+        simulateTabKeyEvent()
+        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 8])
 
     describe "when the prefix contains non-word characters", ->
       it "selects the non-word characters as part of the prefix", ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -589,37 +589,40 @@ describe "Snippets extension", ->
         expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 4]]
 
     describe "when a previous snippet expansion has just been undone", ->
-      it "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
-        editor.insertText 't6\n'
-        editor.setCursorBufferPosition [0, 2]
-        simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "first line"
-        editor.undo()
-        expect(editor.lineTextForBufferRow(0)).toBe "t6"
-        simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "first line"
+      describe "when the tab stops appear in the middle of the snippet", ->
+        it "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
+          editor.insertText 't6\n'
+          editor.setCursorBufferPosition [0, 2]
+          simulateTabKeyEvent()
+          expect(editor.lineTextForBufferRow(0)).toBe "first line"
+          editor.undo()
+          expect(editor.lineTextForBufferRow(0)).toBe "t6"
+          simulateTabKeyEvent()
+          expect(editor.lineTextForBufferRow(0)).toBe "first line"
 
-      it "does not remember the tab stops when the whole snippet has been undone (regression)", ->
-        editor.insertText 't6b\n'
-        editor.setCursorBufferPosition [0, 3]
-        simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
-        editor.undo()
-        expect(editor.lineTextForBufferRow(0)).toBe "t6b"
-        simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
-        expect(editor.getCursorBufferPosition()).toEqual([0, 0])
+      describe "when the tab stops appear at the beginning and then the end of snippet", ->
+        it "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
+          editor.insertText 't6b\n'
+          editor.setCursorBufferPosition [0, 3]
+          simulateTabKeyEvent()
+          expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+          editor.undo()
+          expect(editor.lineTextForBufferRow(0)).toBe "t6b"
+          simulateTabKeyEvent()
+          expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+          expect(editor.getCursorBufferPosition()).toEqual([0, 0])
 
-      it "does not remember the tab stops when the whole snippet has been undone (regression, alternative version)", ->
-        editor.insertText 't6c\n'
-        editor.setCursorBufferPosition [0, 3]
-        simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
-        editor.undo()
-        expect(editor.lineTextForBufferRow(0)).toBe "t6c"
-        simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "expanded"
-        expect(editor.getCursorBufferPosition()).toEqual([0, 8])
+      describe "when the tab stops appear at the end and then the beginning of snippet", ->
+        it "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
+          editor.insertText 't6c\n'
+          editor.setCursorBufferPosition [0, 3]
+          simulateTabKeyEvent()
+          expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+          editor.undo()
+          expect(editor.lineTextForBufferRow(0)).toBe "t6c"
+          simulateTabKeyEvent()
+          expect(editor.lineTextForBufferRow(0)).toBe "expanded"
+          expect(editor.getCursorBufferPosition()).toEqual([0, 8])
 
     describe "when the prefix contains non-word characters", ->
       it "selects the non-word characters as part of the prefix", ->

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -165,11 +165,11 @@ describe "Snippets extension", ->
                 ${2:placeholder ending second line}
             """
 
-          "tab stops at the ends of snippets":
+          "tab stops at beginning and then end of snippet":
             prefix: "t6b"
             body: "$1expanded$0"
 
-          "tab stops at the ends of snippets - alternative":
+          "tab stops at end and then beginning of snippet":
             prefix: "t6c"
             body: "$0expanded$1"
 


### PR DESCRIPTION
### Description of the Change

Adds tests from #261 for an issue that has been since fixed. I could not find any tests that explicitly test this, which this pull request attempts to remedy. These tests fail pre-1.3.0 release.

### Applicable Issues

#261 