### PR TITLE
Don't return an unresolved Promise on beforeEach()

### DIFF
--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -481,6 +481,10 @@ describe "Snippets extension", ->
       describe "when the snippet spans multiple lines", ->
         beforeEach ->
           editor.update({autoIndent: true})
+          # editor.update() returns a Promise that never gets resolved, so we
+          # need to return undefined to avoid a timeout in the spec.
+          # TODO: Figure out why `editor.update({autoIndent: true})` never gets resolved.
+          return
 
         it "places tab stops correctly", ->
           expect(editor.getSoftTabs()).toBeTruthy()


### PR DESCRIPTION
### Description of the Change

The `editor.update()` method returns a Promise, which under some circumstances (on specs mostly) never gets resolved.

Because of CoffeeScript's implicit returns, this Promise was returned on the `beforeEach()` method of these tests.

Before https://github.com/atom/atom/pull/18917, any Promise that was returned by a spec method was just discarded, so this behaviour didn't cause any issue, but once we merge that PR this test is going to start failing because jasmine will wait indefinitely until the Promise is resolved.

### Alternate Designs

Figure out why the Promise that gets returned by `editor.update()` never gets resolved. I've started investigating it and this only happens when [this codepath](https://github.com/atom/atom/blob/master/src/text-editor.js#L535) gets executed.

The official tests for `TextEditor` seem to avoid awaiting for that Promise (e.g if we add an `await` in [this line](https://github.com/atom/atom/blob/master/spec/text-editor-spec.js#L112) that test is going to fail), so I've left the proper investigation in a TODO comment.

### Benefits

This unblocks merging https://github.com/atom/atom/pull/18917

### Possible Drawbacks

N/A

### Applicable Issues

N/A