### PR TITLE
Decouple core indentation logic from spec

### DIFF
--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -583,14 +583,16 @@ describe "Snippets extension", ->
         expect(editor.lineTextForBufferRow(0)).toBe "xxte  var quicksort = function () {"
         expect(editor.getCursorScreenPosition()).toEqual [0, 6]
 
-    describe "when text is selected", ->
-      it "inserts a tab as normal", ->
+    describe "when a snippet matching prefix is selected", ->
+      it "does not expand the snippet", ->
         editor.insertText("t1")
         editor.setSelectedBufferRange([[0, 0], [0, 2]])
+        originalLine = editor.lineTextForBufferRow(0)
 
         simulateTabKeyEvent()
-        expect(editor.lineTextForBufferRow(0)).toBe "  t1var quicksort = function () {"
-        expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 4]]
+        expect(editor.lineTextForBufferRow(0)).not.toEqual originalLine
+        expect(editor.lineTextForBufferRow(0)).toContain "var quicksort = function () {"
+        expect(editor.lineTextForBufferRow(0)).not.toContain "this is a test"
 
     describe "when a previous snippet expansion has just been undone", ->
       describe "when the tab stops appear in the middle of the snippet", ->


### PR DESCRIPTION
### Description of the Change

This pull request changes a test in spec suite which at the time of writing expects a very specfic indentation logic behavior from core: it assumes that when text is selected, hitting <kbd>Tab</kbd> always results in indenting the line. The aim of the pull request is somewhat to loosen the test to allow any core behavior (within reason) to occur, while retaining the constraints that make sense for this package.

### Alternate Designs

None considered for now.

### Benefits

The test is not as tightly coupled to the core, allowing core to change behavior without the need to update this spec.

### Possible Drawbacks

There could be future developments which may pass with the new test, but that did not pass with the old one, however this should be unlikely due to the amount of similar tests which possibly catch such cases.

### Applicable Issues

atom/atom#20137