### PR TITLE
Indent tab stops that start from the first line of snippet properly

### DIFF
--- a/lib/tab-stop.js
+++ b/lib/tab-stop.js
@@ -43,6 +43,8 @@ class TabStop {
       if (newRange.start.row) {
         newRange.start.column += indent.length
         newRange.end.column += indent.length
+      } else if (newRange.start.row !== newRange.end.row) {
+        newRange.end.column += indent.length
       }
       return new Insertion({
         range: newRange,

--- a/spec/snippets-spec.js
+++ b/spec/snippets-spec.js
@@ -284,6 +284,10 @@ third tabstop $3\
           "has a transformed tab stop such that it is possible to move the cursor between the ordinary tab stop and its transformed version without an intermediate step": {
             prefix: 't18',
             body: '// $1\n// ${1/./=/}'
+          },
+          "has a tab stop from end of first line till the beginning of last line": {
+            prefix: 't19',
+            body: '<tag>${1:\n\t$0\n}</tag>'
           }
         }
       });
@@ -581,6 +585,15 @@ third tabstop $3\
           expect(editor.lineTextForBufferRow(4)).toBe("      line 2");
           expect(editor.lineTextForBufferRow(5)).toBe("    }");
           expect(editor.getCursorBufferPosition()).toEqual([3, 4]);
+        });
+
+        it("indents the ending tab stop if it starts from the first line (regression)", () => {
+          editor.setCursorScreenPosition([2, Infinity]);
+          editor.insertNewline();
+          editor.insertText('t19');
+          atom.commands.dispatch(editorElement, 'snippets:expand');
+
+          expect(editor.getSelectedBufferRange()).toEqual([[3, 9], [5, 4]]);
         });
 
         it("does not change the relative positioning of the tab stops when inserted multiple times", () => {


### PR DESCRIPTION
### Description of the Change

This fixes a simple case of tab stop indentation not applying properly if following conditions are met:
1) The snippet's tab stop starts from the initial line of the snippet and ends on another line
2) The snippet expanded on an indented position on the document.

### Alternate Designs

None considered.

### Benefits

Bugfix.

### Possible Drawbacks

Anticipating none.

### Applicable Issues

https://github.com/jawee/language-blade/pull/92#issuecomment-617343497