### PR TITLE
add windows core package detection

### DIFF
--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -11,6 +11,9 @@ const SnippetExpansion = require('./snippet-expansion')
 const EditorStore = require('./editor-store')
 const {getPackageRoot} = require('./helpers')
 
+// Used to guess if the snippets file comes from a core package (bundled with Atom) or not
+const IS_CORE_PACKAGE = process.platform === "win32" ? /\\node_modules\\/ : /\/node_modules\//
+
 module.exports = {
   activate () {
     this.loaded = false
@@ -218,7 +221,7 @@ module.exports = {
   loadPackageSnippets (callback) {
     const disabledPackageNames = atom.config.get('core.packagesWithSnippetsDisabled') || []
     const packages = atom.packages.getLoadedPackages().sort((pack, _) => {
-      return /\/node_modules\//.test(pack.path) ? -1 : 1
+      return IS_CORE_PACKAGE.test(pack.path) ? -1 : 1
     })
 
     const snippetsDirPaths = []


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

On Windows the snippet file paths use `\` as the delimiter. This doesn't match the `/node_modules/` regex, so community snippets don't get priority.

The change sets the regex depending on if the OS is Windows or not.

### Alternate Designs

None

### Benefits

Priority test passes

### Possible Drawbacks

I don't know why this issue suddenly appeared. It came up in #306, but the cause does not seem to be related to that PR. The check itself has existed (in similar form) for years. The path comes from the Atom package manager module, so perhaps it used to normalise them? Or the files just happened to be in the right order other times? 

### Applicable Issues

None
